### PR TITLE
Show radius in start message properly

### DIFF
--- a/src/main/java/org/popcraft/chunky/command/StartCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/StartCommand.java
@@ -19,6 +19,7 @@ public class StartCommand extends ChunkyCommand {
         GenerationTask generationTask = new GenerationTask(chunky, selection);
         chunky.getGenerationTasks().put(selection.world, generationTask);
         chunky.getServer().getScheduler().runTaskAsynchronously(chunky, generationTask);
-        sender.sendMessage(chunky.message("format_start", chunky.message("prefix"), selection.world.getName(), selection.centerX, selection.centerZ, selection.radiusX));
+        String radius = selection.radiusX == selection.radiusZ ? String.valueOf(selection.radiusX) : String.format("%d, %d", selection.radiusX, selection.radiusZ);
+        sender.sendMessage(chunky.message("format_start", chunky.message("prefix"), selection.world.getName(), selection.centerX, selection.centerZ, radius));
     }
 }

--- a/src/main/resources/lang/bg.json
+++ b/src/main/resources/lang/bg.json
@@ -12,7 +12,7 @@
   "format_radius": "%s Радиус променен на %d.",
   "format_shape": "%s Форма променена на %s.",
   "format_silent": "%s Тих режим %s.",
-  "format_start": "%s Задача стартирана за %s на %d, %d с радиус %d.",
+  "format_start": "%s Задача стартирана за %s на %d, %d с радиус %s.",
   "format_started_already": "%s Задачата е вече стартирана за %s!",
   "format_world": "%s Свят променен на %s.",
   "help_cancel": "&2chunky cancel&r - Спиране и изтриване на текущи или запазени задачи",

--- a/src/main/resources/lang/de.json
+++ b/src/main/resources/lang/de.json
@@ -13,7 +13,7 @@
   "format_radius": "%s Radius geändert zu %d.",
   "format_shape": "%s Form geändert zu %s.",
   "format_silent": "%s Stummer Modus %s.",
-  "format_start": "%s Aufgabe gestartet für %s bei %d, %d mit Radius %d.",
+  "format_start": "%s Aufgabe gestartet für %s bei %d, %d mit Radius %s.",
   "format_started_already": "%s Aufgabe für %s bereits gestartet!",
   "format_world": "%s Welt geändert zu %s.",
   "help_cancel": "&2chunky cancel&r - Stope und lösche alle momentan gespeicherten Aufgaben",

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -13,7 +13,7 @@
   "format_radius": "%s Radius changed to %d.",
   "format_shape": "%s Shape changed to %s.",
   "format_silent": "%s Silent mode %s.",
-  "format_start": "%s Task started for %s at %d, %d with radius %d.",
+  "format_start": "%s Task started for %s at %d, %d with radius %s.",
   "format_started_already": "%s Task already started for %s!",
   "format_world": "%s World changed to %s.",
   "help_cancel": "&2chunky cancel&r - Stop and delete current or saved tasks",

--- a/src/main/resources/lang/es.json
+++ b/src/main/resources/lang/es.json
@@ -13,7 +13,7 @@
   "format_radius": "%s Distancia cambiada a %d.",
   "format_shape": "%s La forma cambio a %s.",
   "format_silent": "%s El modo silencioso esta %s.",
-  "format_start": "%s Tarea iniciada en %s %d, %d con un area de %d.",
+  "format_start": "%s Tarea iniciada en %s %d, %d con un area de %s.",
   "format_started_already": "%s Tarea ya iniciada para %s!",
   "format_world": "%s Mundo cambiado a %s.",
   "help_cancel": "&2chunky cancel&r - Detiene y elimina las tareas actuales o guardadas",

--- a/src/main/resources/lang/fr.json
+++ b/src/main/resources/lang/fr.json
@@ -10,7 +10,7 @@
   "format_quiet": "%s Intervalle de silence réglé à %d secondes.",
   "format_radius": "%s Le rayon est passé à %d.",
   "format_silent": "%s Mode silencieux %s.",
-  "format_start": "%s La tâche a commencé pour %s à %d, %d avec un rayon de %d.",
+  "format_start": "%s La tâche a commencé pour %s à %d, %d avec un rayon de %s.",
   "format_started_already": "%s La tâche a déjà commencé pour %s!",
   "format_world": "%s Le monde est passé à %s.",
   "help_cancel": "&2chunky cancel&r - Arrêter et supprimer les tâches en cours ou enregistrées",

--- a/src/main/resources/lang/pt.json
+++ b/src/main/resources/lang/pt.json
@@ -10,7 +10,7 @@
   "format_quiet": "%s Intervalo silencioso definido para %d segundos.",
   "format_radius": "%s O raio mudou para %d.",
   "format_silent": "%s Modo silencioso %s.",
-  "format_start": "%s Tarefa iniciada para %s em %d, %d com raio de %d.",
+  "format_start": "%s Tarefa iniciada para %s em %d, %d com raio de %s.",
   "format_started_already": "%s Tarefa já iniciada para %s !",
   "format_world": "%s O mundo mudou para %s.",
   "help_cancel": "&2chunky cancel&r - Parar e apagar tarefas actuais ou guardadas",

--- a/src/main/resources/lang/ru.json
+++ b/src/main/resources/lang/ru.json
@@ -13,7 +13,7 @@
   "format_radius": "%s Радиус изменен на %d.",
   "format_silent": "%s Тихий режим %s.",
   "format_shape": "%s Форма изменена на %s.",
-  "format_start": "%s Задача для %s запущена с центром в %d, %d и с радиусом %d.",
+  "format_start": "%s Задача для %s запущена с центром в %d, %d и с радиусом %s.",
   "format_started_already": "%s Задача для %s уже запущена!",
   "format_world": "%s Мир изменен на %s.",
   "help_cancel": "&2chunky cancel&r - установить и удалить текущие или сохраненные задачи",

--- a/src/main/resources/lang/tr.json
+++ b/src/main/resources/lang/tr.json
@@ -10,7 +10,7 @@
   "format_quiet": "%s Sessiz aralık %d saniye olarak yarlandı.",
   "format_radius": "%s Yarıçap %d olarak ayarlandı.",
   "format_silent": "%s Sessiz mod %s.",
-  "format_start": "%s Fonksiyon %s için %d, %d ve yarıçap %d olarak ayarlandı.",
+  "format_start": "%s Fonksiyon %s için %d, %d ve yarıçap %s olarak ayarlandı.",
   "format_started_already": "%s %s için fonksiyon zaten başladı!",
   "format_world": "%s Dünya %s olarak değiştirildi.",
   "help_cancel": "&2chunky cancel&r - Mevcut veya kayıtlı fonksiyonları durdurun ve silin",

--- a/src/main/resources/lang/zh_CN.json
+++ b/src/main/resources/lang/zh_CN.json
@@ -13,7 +13,7 @@
   "format_radius": "%s 生成范围半径已更改为 %d。",
   "format_shape": "%s 预生成形状已更改为 %s。",
   "format_silent": "%s 静默模式 %s。",
-  "format_start": "%s 任务开始于模式 %s 以间隔 %d, %d 以 %d 的范围进行。",
+  "format_start": "%s 任务开始于模式 %s 以间隔 %d, %d 以 %s 的范围进行。",
   "format_started_already": "%s 任务已经持续了 %s!",
   "format_world": "%s 世界被改变为 %s。",
   "help_cancel": "&2chunky cancel&r - 取消并删除当前正在运行或已保存的任务",


### PR DESCRIPTION
Fixes an issue where when using two radii, starting a task would confusingly not show the second radius.