### PR TITLE
Provide a better message if trying to cancel with no tasks

### DIFF
--- a/src/main/java/org/popcraft/chunky/command/CancelCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/CancelCommand.java
@@ -9,6 +9,10 @@ public class CancelCommand extends ChunkyCommand {
     }
 
     public void execute(CommandSender sender, String[] args) {
+        if (chunky.getGenerationTasks().size() == 0 && chunky.getConfigStorage().loadTasks().size() == 0) {
+            sender.sendMessage(chunky.message("format_cancel_no_tasks", chunky.message("prefix")));
+            return;
+        }
         sender.sendMessage(chunky.message("format_cancel", chunky.message("prefix")));
         chunky.getConfigStorage().cancelTasks();
         chunky.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(true));

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -4,6 +4,7 @@
   "error_version": "This plugin is not compatible with Minecraft versions below 1.13.",
   "error_version_spigot": "This plugin is not compatible with Spigot 1.13!",
   "format_cancel": "%s Cancelling all tasks.",
+  "format_cancel_no_tasks": "%s No tasks to cancel.",
   "format_center": "%s Center changed to %d, %d.",
   "format_continue": "%s Task continuing for %s.",
   "format_pattern": "%s Pattern changed to %s.",


### PR DESCRIPTION
This changes the cancel command to properly inform the user if any tasks were actually cancelled, rather than just always saying that all tasks were cancelled.

Hopefully good enough, let me know if you want to see any changes <3