### PR TITLE
Improve shutdown by saving tasks sync

### DIFF
--- a/src/main/java/org/popcraft/chunky/Chunky.java
+++ b/src/main/java/org/popcraft/chunky/Chunky.java
@@ -61,7 +61,7 @@ public final class Chunky extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        commands.get("pause").execute(getServer().getConsoleSender(), new String[]{});
+        this.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(false, true));
         this.getServer().getScheduler().getActiveWorkers().stream()
                 .filter(w -> w.getOwner() == this)
                 .map(BukkitWorker::getThread)

--- a/src/main/java/org/popcraft/chunky/Chunky.java
+++ b/src/main/java/org/popcraft/chunky/Chunky.java
@@ -62,6 +62,7 @@ public final class Chunky extends JavaPlugin {
     @Override
     public void onDisable() {
         this.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(false, true));
+        this.setNaggable(false);
         this.getServer().getScheduler().getActiveWorkers().stream()
                 .filter(w -> w.getOwner() == this)
                 .map(BukkitWorker::getThread)

--- a/src/main/java/org/popcraft/chunky/Chunky.java
+++ b/src/main/java/org/popcraft/chunky/Chunky.java
@@ -62,7 +62,6 @@ public final class Chunky extends JavaPlugin {
     @Override
     public void onDisable() {
         this.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(false, true));
-        this.setNaggable(false);
         this.getServer().getScheduler().getActiveWorkers().stream()
                 .filter(w -> w.getOwner() == this)
                 .map(BukkitWorker::getThread)

--- a/src/main/java/org/popcraft/chunky/ConfigStorage.java
+++ b/src/main/java/org/popcraft/chunky/ConfigStorage.java
@@ -67,7 +67,7 @@ public class ConfigStorage {
 
     public synchronized void cancelTasks() {
         loadTasks().forEach(generationTask -> {
-            generationTask.stop(true);
+            generationTask.stop(true, false);
             saveTask(generationTask);
         });
     }

--- a/src/main/java/org/popcraft/chunky/GenerationTask.java
+++ b/src/main/java/org/popcraft/chunky/GenerationTask.java
@@ -114,7 +114,6 @@ public class GenerationTask implements Runnable {
                 }
             });
         }
-        totalTime += prevTime + (System.currentTimeMillis() - startTime.get());
         if (stopped) {
             chunky.getServer().getConsoleSender().sendMessage(chunky.message("task_stopped", chunky.message("prefix"), world.getName()));
         } else {
@@ -129,6 +128,7 @@ public class GenerationTask implements Runnable {
         this.stopped = true;
         this.cancelled = cancelled;
         if (save && !hasSaved) {
+            totalTime += prevTime + (System.currentTimeMillis() - startTime.get());
             chunky.getConfigStorage().saveTask(this);
             this.hasSaved = true;
         }

--- a/src/main/java/org/popcraft/chunky/GenerationTask.java
+++ b/src/main/java/org/popcraft/chunky/GenerationTask.java
@@ -18,7 +18,7 @@ public class GenerationTask implements Runnable {
     private final int radiusX, radiusZ, centerX, centerZ;
     private ChunkIterator chunkIterator;
     private Shape shape;
-    private boolean stopped, cancelled;
+    private boolean stopped, cancelled, hasSaved;
     private long prevTime, totalTime;
     private final AtomicLong startTime = new AtomicLong();
     private final AtomicLong printTime = new AtomicLong();
@@ -103,7 +103,7 @@ public class GenerationTask implements Runnable {
             try {
                 working.acquire();
             } catch (InterruptedException e) {
-                stop(cancelled);
+                stop(cancelled, false);
                 break;
             }
             PaperLib.getChunkAtAsync(world, chunkCoord.x, chunkCoord.z).thenAccept(chunk -> {
@@ -120,14 +120,18 @@ public class GenerationTask implements Runnable {
         } else {
             this.cancelled = true;
         }
-        chunky.getConfigStorage().saveTask(this);
+        stop(cancelled, true);
         chunky.getGenerationTasks().remove(this.getWorld());
         Thread.currentThread().setName(poolThreadName);
     }
 
-    public void stop(boolean cancelled) {
+    public void stop(boolean cancelled, boolean save) {
         this.stopped = true;
         this.cancelled = cancelled;
+        if (save && !hasSaved) {
+            chunky.getConfigStorage().saveTask(this);
+            this.hasSaved = true;
+        }
     }
 
     public World getWorld() {

--- a/src/main/java/org/popcraft/chunky/command/CancelCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/CancelCommand.java
@@ -11,7 +11,7 @@ public class CancelCommand extends ChunkyCommand {
     public void execute(CommandSender sender, String[] args) {
         sender.sendMessage(chunky.message("format_cancel", chunky.message("prefix")));
         chunky.getConfigStorage().cancelTasks();
-        chunky.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(true));
+        chunky.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(true, false));
         chunky.getGenerationTasks().clear();
         chunky.getServer().getScheduler().cancelTasks(chunky);
     }

--- a/src/main/java/org/popcraft/chunky/command/PauseCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/PauseCommand.java
@@ -11,7 +11,7 @@ public class PauseCommand extends ChunkyCommand {
 
     public void execute(CommandSender sender, String[] args) {
         for (GenerationTask generationTask : chunky.getGenerationTasks().values()) {
-            generationTask.stop(false);
+            generationTask.stop(false, false);
             sender.sendMessage(chunky.message("format_pause", chunky.message("prefix"), generationTask.getWorld().getName()));
         }
     }


### PR DESCRIPTION
If shutting down, save tasks sync. This should fix issues that people are having with tasks not saving properly or the async task taking too long to shut down.