### PR TITLE
Provide a better message if trying to pause with no tasks

### DIFF
--- a/src/main/java/org/popcraft/chunky/command/PauseCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/PauseCommand.java
@@ -10,6 +10,10 @@ public class PauseCommand extends ChunkyCommand {
     }
 
     public void execute(CommandSender sender, String[] args) {
+        if (chunky.getGenerationTasks().size() == 0) {
+            sender.sendMessage(chunky.message("format_pause_no_tasks", chunky.message("prefix")));
+            return;
+        }
         for (GenerationTask generationTask : chunky.getGenerationTasks().values()) {
             generationTask.stop(false);
             sender.sendMessage(chunky.message("format_pause", chunky.message("prefix"), generationTask.getWorld().getName()));

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -9,6 +9,7 @@
   "format_continue": "%s Task continuing for %s.",
   "format_pattern": "%s Pattern changed to %s.",
   "format_pause": "%s Task paused for %s.",
+  "format_pause_no_tasks": "%s No tasks to pause.",
   "format_quiet": "%s Quiet interval set to %d seconds.",
   "format_radii": "%s Radius changed for x to %d, and for z to %d.",
   "format_radius": "%s Radius changed to %d.",


### PR DESCRIPTION
This changes the pause command to properly inform the user if there were no tasks to pause, rather than returning nothing and leaving the user with no command feedback whatsoever.

Hopefully good enough, let me know if you want to see any changes <3