### PR TITLE
Provide a better message if trying to continue with no tasks

### DIFF
--- a/src/main/java/org/popcraft/chunky/command/ContinueCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/ContinueCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandSender;
 import org.popcraft.chunky.Chunky;
 import org.popcraft.chunky.GenerationTask;
 
+import java.util.List;
 import java.util.Map;
 
 public class ContinueCommand extends ChunkyCommand {
@@ -13,12 +14,13 @@ public class ContinueCommand extends ChunkyCommand {
     }
 
     public void execute(CommandSender sender, String[] args) {
-        if (chunky.getConfigStorage().loadTasks().size() == 0) {
+        final List<GenerationTask> loadTasks = chunky.getConfigStorage().loadTasks();
+        if (loadTasks.size() == 0) {
             sender.sendMessage(chunky.message("format_continue_no_tasks", chunky.message("prefix")));
             return;
         }
         final Map<World, GenerationTask> generationTasks = chunky.getGenerationTasks();
-        chunky.getConfigStorage().loadTasks().forEach(generationTask -> {
+        loadTasks.forEach(generationTask -> {
             if (!generationTasks.containsKey(generationTask.getWorld())) {
                 generationTasks.put(generationTask.getWorld(), generationTask);
                 chunky.getServer().getScheduler().runTaskAsynchronously(chunky, generationTask);

--- a/src/main/java/org/popcraft/chunky/command/ContinueCommand.java
+++ b/src/main/java/org/popcraft/chunky/command/ContinueCommand.java
@@ -13,6 +13,10 @@ public class ContinueCommand extends ChunkyCommand {
     }
 
     public void execute(CommandSender sender, String[] args) {
+        if (chunky.getConfigStorage().loadTasks().size() == 0) {
+            sender.sendMessage(chunky.message("format_continue_no_tasks", chunky.message("prefix")));
+            return;
+        }
         final Map<World, GenerationTask> generationTasks = chunky.getGenerationTasks();
         chunky.getConfigStorage().loadTasks().forEach(generationTask -> {
             if (!generationTasks.containsKey(generationTask.getWorld())) {

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -7,6 +7,7 @@
   "format_cancel_no_tasks": "%s No tasks to cancel.",
   "format_center": "%s Center changed to %d, %d.",
   "format_continue": "%s Task continuing for %s.",
+  "format_continue_no_tasks": "%s No tasks to continue.",
   "format_pattern": "%s Pattern changed to %s.",
   "format_pause": "%s Task paused for %s.",
   "format_pause_no_tasks": "%s No tasks to pause.",


### PR DESCRIPTION
This changes the continue command to properly inform the user if there were no tasks to continue, rather than returning nothing and leaving the user with no command feedback whatsoever.

This is the last PR I'll be doing that involve these command feedback stuff :P This was the last command that provided no feedback in Chunky. They now all give some sort of feedback always :)

Hopefully good enough, let me know if you want to see any changes <3