### PR TITLE
[Forge] Migrate from MCP to Mojang Mappings

### DIFF
--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    id("dev.architectury.loom") version "0.7.2-SNAPSHOT"
+    id("dev.architectury.loom") version "0.7.3-SNAPSHOT"
 }
 
 dependencies {
     minecraft(group = "com.mojang", name = "minecraft", version = "1.16.5")
-    mappings(group = "de.oceanlabs.mcp", name = "mcp_snapshot", version = "20210309-1.16.5")
+    mappings(minecraft.officialMojangMappings())
     forge(group = "net.minecraftforge", name = "forge", version = "1.16.5-36.1.13")
     implementation(project(":chunky-common"))
 }

--- a/forge/src/main/java/org/popcraft/chunky/ChunkyForge.java
+++ b/forge/src/main/java/org/popcraft/chunky/ChunkyForge.java
@@ -2,7 +2,7 @@ package org.popcraft.chunky;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -25,9 +25,9 @@ import java.util.Map;
 import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.arguments.StringArgumentType.string;
 import static com.mojang.brigadier.arguments.StringArgumentType.word;
-import static net.minecraft.command.Commands.argument;
-import static net.minecraft.command.Commands.literal;
-import static net.minecraft.command.arguments.DimensionArgument.getDimension;
+import static net.minecraft.commands.Commands.argument;
+import static net.minecraft.commands.Commands.literal;
+import static net.minecraft.commands.arguments.DimensionArgument.dimension;
 
 @Mod(ChunkyForge.MODID)
 public class ChunkyForge {
@@ -43,7 +43,7 @@ public class ChunkyForge {
     public void onServerStarting(FMLServerStartingEvent event) {
         MinecraftServer server = event.getServer();
         this.chunky = new Chunky(new ForgeServer(this, server));
-        File configFile = new File(event.getServer().getDataDirectory(), "config/chunky.json");
+        File configFile = new File(event.getServer().getServerDirectory(), "config/chunky.json");
         chunky.setConfig(new GsonConfig(chunky, configFile));
         chunky.setLanguage(chunky.getConfig().getLanguage());
         chunky.loadCommands();
@@ -51,7 +51,7 @@ public class ChunkyForge {
         if (chunky.getConfig().getContinueOnRestart()) {
             chunky.getCommands().get("continue").execute(chunky.getServer().getConsoleSender(), new String[]{});
         }
-        Command<CommandSource> command = context -> {
+        Command<CommandSourceStack> command = context -> {
             Sender sender = new ForgeSender(context.getSource());
             Map<String, ChunkyCommand> commands = chunky.getCommands();
             String input = context.getInput();
@@ -61,9 +61,9 @@ public class ChunkyForge {
             commands.get(subCommand).execute(sender, args);
             return Command.SINGLE_SUCCESS;
         };
-        server.getCommandManager().getDispatcher().register(LiteralArgumentBuilder.<CommandSource>literal("chunky")
+        server.getCommands().getDispatcher().register(LiteralArgumentBuilder.<CommandSourceStack>literal("chunky")
                 .then(literal("cancel")
-                        .then(argument("world", getDimension())
+                        .then(argument("world", dimension())
                                 .executes(command))
                         .executes(command))
                 .then(literal("center")
@@ -75,7 +75,7 @@ public class ChunkyForge {
                 .then(literal("confirm")
                         .executes(command))
                 .then(literal("continue")
-                        .then(argument("world", getDimension())
+                        .then(argument("world", dimension())
                                 .executes(command))
                         .executes(command))
                 .then(literal("corners")
@@ -98,7 +98,7 @@ public class ChunkyForge {
                                 .executes(command))
                         .executes(command))
                 .then(literal("pause")
-                        .then(argument("world", getDimension())
+                        .then(argument("world", dimension())
                                 .executes(command))
                         .executes(command))
                 .then(literal("quiet")
@@ -123,7 +123,7 @@ public class ChunkyForge {
                 .then(literal("spawn")
                         .executes(command))
                 .then(literal("start")
-                        .then(argument("world", getDimension())
+                        .then(argument("world", dimension())
                                 .then(argument("shape", string())
                                         .then(argument("centerX", word())
                                                 .then(argument("centerZ", word())
@@ -138,7 +138,7 @@ public class ChunkyForge {
                                 .executes(command))
                         .executes(command))
                 .then(literal("trim")
-                        .then(argument("world", getDimension())
+                        .then(argument("world", dimension())
                                 .then(argument("shape", string())
                                         .then(argument("centerX", word())
                                                 .then(argument("centerZ", word())
@@ -155,11 +155,11 @@ public class ChunkyForge {
                 .then(literal("worldborder")
                         .executes(command))
                 .then(literal("world")
-                        .then(argument("world", getDimension())
+                        .then(argument("world", dimension())
                                 .executes(command))
                         .executes(command))
                 .executes(command)
-                .requires(serverCommandSource -> serverCommandSource.hasPermissionLevel(2)));
+                .requires(serverCommandSource -> serverCommandSource.hasPermission(2)));
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/org/popcraft/chunky/command/suggestion/PatternSuggestionProvider.java
+++ b/forge/src/main/java/org/popcraft/chunky/command/suggestion/PatternSuggestionProvider.java
@@ -4,14 +4,14 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
-import net.minecraft.command.CommandSource;
 import org.popcraft.chunky.util.Input;
 
 import java.util.concurrent.CompletableFuture;
+import net.minecraft.commands.CommandSourceStack;
 
-public class PatternSuggestionProvider implements SuggestionProvider<CommandSource> {
+public class PatternSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
     @Override
-    public CompletableFuture<Suggestions> getSuggestions(CommandContext<CommandSource> context, SuggestionsBuilder builder) {
+    public CompletableFuture<Suggestions> getSuggestions(CommandContext<CommandSourceStack> context, SuggestionsBuilder builder) {
         try {
             final String input = context.getArgument("pattern", String.class);
             Input.PATTERNS.forEach(pattern -> {

--- a/forge/src/main/java/org/popcraft/chunky/command/suggestion/ShapeSuggestionProvider.java
+++ b/forge/src/main/java/org/popcraft/chunky/command/suggestion/ShapeSuggestionProvider.java
@@ -4,14 +4,14 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
-import net.minecraft.command.CommandSource;
 import org.popcraft.chunky.util.Input;
 
 import java.util.concurrent.CompletableFuture;
+import net.minecraft.commands.CommandSourceStack;
 
-public class ShapeSuggestionProvider implements SuggestionProvider<CommandSource> {
+public class ShapeSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
     @Override
-    public CompletableFuture<Suggestions> getSuggestions(CommandContext<CommandSource> context, SuggestionsBuilder builder) {
+    public CompletableFuture<Suggestions> getSuggestions(CommandContext<CommandSourceStack> context, SuggestionsBuilder builder) {
         try {
             final String input = context.getArgument("shape", String.class);
             Input.SHAPES.forEach(shape -> {

--- a/forge/src/main/java/org/popcraft/chunky/command/suggestion/SuggestionProviders.java
+++ b/forge/src/main/java/org/popcraft/chunky/command/suggestion/SuggestionProviders.java
@@ -1,11 +1,11 @@
 package org.popcraft.chunky.command.suggestion;
 
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
 
 public class SuggestionProviders {
-    public static final SuggestionProvider<CommandSource> PATTERNS;
-    public static final SuggestionProvider<CommandSource> SHAPES;
+    public static final SuggestionProvider<CommandSourceStack> PATTERNS;
+    public static final SuggestionProvider<CommandSourceStack> SHAPES;
 
     static {
         PATTERNS = new PatternSuggestionProvider();

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeBorder.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeBorder.java
@@ -1,6 +1,6 @@
 package org.popcraft.chunky.platform;
 
-import net.minecraft.world.border.WorldBorder;
+import net.minecraft.world.level.border.WorldBorder;
 import org.popcraft.chunky.util.Coordinate;
 
 public class ForgeBorder implements Border {
@@ -17,12 +17,12 @@ public class ForgeBorder implements Border {
 
     @Override
     public double getRadiusX() {
-        return worldBorder.getDiameter() / 2d;
+        return worldBorder.getSize() / 2d;
     }
 
     @Override
     public double getRadiusZ() {
-        return worldBorder.getDiameter() / 2d;
+        return worldBorder.getSize() / 2d;
     }
 
     @Override

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeSender.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeSender.java
@@ -1,31 +1,31 @@
 package org.popcraft.chunky.platform;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import net.minecraft.command.CommandSource;
-import net.minecraft.entity.player.ServerPlayerEntity;
-import net.minecraft.util.math.vector.Vector3d;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.phys.Vec3;
 import org.popcraft.chunky.util.Coordinate;
 
 import static org.popcraft.chunky.util.Translator.translateKey;
 
 public class ForgeSender implements Sender {
-    private CommandSource source;
+    private CommandSourceStack source;
 
-    public ForgeSender(CommandSource source) {
+    public ForgeSender(CommandSourceStack source) {
         this.source = source;
     }
 
     @Override
     public boolean isPlayer() {
-        return source.getEntity() instanceof ServerPlayerEntity;
+        return source.getEntity() instanceof ServerPlayer;
     }
 
     @Override
     public String getName() {
         try {
-            return source.asPlayer().getName().getString();
+            return source.getPlayerOrException().getName().getString();
         } catch (CommandSyntaxException e) {
             return "Console";
         }
@@ -33,14 +33,14 @@ public class ForgeSender implements Sender {
 
     @Override
     public Coordinate getCoordinate() {
-        Vector3d pos = source.getPos();
-        return new Coordinate((long) pos.getX(), (long) pos.getZ());
+        Vec3 pos = source.getPosition();
+        return new Coordinate((long) pos.x(), (long) pos.z());
     }
 
     @Override
     public void sendMessage(String key, boolean prefixed, Object... args) {
         String text = translateKey(key, prefixed, args).replaceAll("&(?=[0-9a-fk-orA-FK-OR])", "§");
-        ITextComponent textComponent = new StringTextComponent(text);
-        source.sendFeedback(textComponent, false);
+        Component textComponent = new TextComponent(text);
+        source.sendSuccess(textComponent, false);
     }
 }

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeServer.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeServer.java
@@ -1,9 +1,9 @@
 package org.popcraft.chunky.platform;
 
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.RegistryKey;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.Registry;
 import org.popcraft.chunky.ChunkyForge;
 import org.popcraft.chunky.integration.Integration;
 import org.popcraft.chunky.platform.impl.SimpleScheduler;
@@ -32,24 +32,24 @@ public class ForgeServer implements Server {
 
     @Override
     public Optional<World> getWorld(String name) {
-        ResourceLocation resourceLocation = ResourceLocation.tryCreate(name);
+        ResourceLocation resourceLocation = ResourceLocation.tryParse(name);
         if (resourceLocation == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(server.getWorld(RegistryKey.getOrCreateKey(Registry.WORLD_KEY, resourceLocation)))
+        return Optional.ofNullable(server.getLevel(ResourceKey.create(Registry.DIMENSION_REGISTRY, resourceLocation)))
                 .map(ForgeWorld::new);
     }
 
     @Override
     public List<World> getWorlds() {
         List<World> worlds = new ArrayList<>();
-        server.getWorlds().forEach(world -> worlds.add(new ForgeWorld(world)));
+        server.getAllLevels().forEach(world -> worlds.add(new ForgeWorld(world)));
         return worlds;
     }
 
     @Override
     public Sender getConsoleSender() {
-        return new ForgeSender(server.getCommandSource());
+        return new ForgeSender(server.createCommandSourceStack());
     }
 
     @Override


### PR DESCRIPTION
This PR addresses the [discontinuation of MCP mappings](https://mcforge.readthedocs.io/en/latest/gettingstarted/#migration-to-mojangs-official-mappings) by migrating to the official Mojang mappings, which is the recommended migration path.

This is an important step towards 1.17.

Reminder that the mappings come with the following license:
`(c) 2020 Microsoft Corporation. These mappings are provided "as-is" and you bear the risk of using them. You may copy and use the mappings for development purposes, but you may not redistribute the mappings complete and unmodified. Microsoft makes no warranties, express or implied, with respect to the mappings provided here.  Use and modification of this document or the source code (in any form) of Minecraft: Java Edition is governed by the Minecraft End User License Agreement available at https://account.mojang.com/documents/minecraft_eula. `