### PR TITLE
[Fabric] Update Loom to 0.9

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("fabric-loom") version "0.8-SNAPSHOT"
+    id("fabric-loom") version "0.9-SNAPSHOT"
 }
 
 dependencies {


### PR DESCRIPTION
This PR addresses the Gradle deprecation warnings during normal build as well as the massive spam during loom operations by updating to Loom 0.9 - which has been promoted to stable as of today.