### PR TITLE
[Forge] Improve parity with Fabric

### DIFF
--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     minecraft(group = "com.mojang", name = "minecraft", version = "1.16.5")
     mappings(minecraft.officialMojangMappings())
-    forge(group = "net.minecraftforge", name = "forge", version = "1.16.5-36.1.13")
+    forge(group = "net.minecraftforge", name = "forge", version = "1.16.5-36.2.0")
     implementation(project(":chunky-common"))
 }
 

--- a/forge/src/main/java/org/popcraft/chunky/ChunkyForge.java
+++ b/forge/src/main/java/org/popcraft/chunky/ChunkyForge.java
@@ -5,13 +5,16 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
+import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.popcraft.chunky.command.ChunkyCommand;
+import org.popcraft.chunky.listeners.BossBarProgress;
 import org.popcraft.chunky.platform.ForgeSender;
 import org.popcraft.chunky.platform.ForgeServer;
 import org.popcraft.chunky.platform.Sender;
@@ -101,6 +104,8 @@ public class ChunkyForge {
                         .then(argument("world", dimension())
                                 .executes(command))
                         .executes(command))
+                .then(literal("progress")
+                        .executes(command))
                 .then(literal("quiet")
                         .then(argument("interval", integer())
                                 .executes(command))
@@ -167,6 +172,16 @@ public class ChunkyForge {
         chunky.getConfig().saveTasks();
         chunky.getGenerationTasks().values().forEach(generationTask -> generationTask.stop(false));
         chunky.getServer().getScheduler().cancelTasks();
+    }
+
+    @SubscribeEvent
+    public void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+            if (server != null) {
+                BossBarProgress.tick(chunky, server);
+            }
+        }
     }
 
     public Chunky getChunky() {

--- a/forge/src/main/java/org/popcraft/chunky/listeners/BossBarProgress.java
+++ b/forge/src/main/java/org/popcraft/chunky/listeners/BossBarProgress.java
@@ -1,0 +1,78 @@
+package org.popcraft.chunky.listeners;
+
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.bossevents.CustomBossEvent;
+import net.minecraft.server.bossevents.CustomBossEvents;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.BossEvent;
+import net.minecraft.world.level.dimension.DimensionType;
+import org.popcraft.chunky.Chunky;
+import org.popcraft.chunky.GenerationTask;
+import org.popcraft.chunky.platform.ForgeWorld;
+
+public class BossBarProgress {
+    public static void tick(final Chunky chunky, final MinecraftServer server) {
+        final int quietInterval = Math.max(1, chunky.getOptions().getQuietInterval() * 20);
+        if (server.getTickCount() % quietInterval != 0) {
+            return;
+        }
+        for (ServerLevel world : server.getAllLevels()) {
+            final ResourceLocation worldId = world.dimension().location();
+            final ResourceLocation barId = ResourceLocation.tryParse("chunky:progress_" + worldId.toString().replace(':', '_'));
+            if (barId == null) {
+                continue;
+            }
+            final CustomBossEvents bossBarManager = server.getCustomBossEvents();
+            final GenerationTask task = chunky.getGenerationTasks().get(new ForgeWorld(world));
+            final boolean barExists = bossBarManager.get(barId) != null;
+            if (task == null && !barExists) {
+                continue;
+            }
+            final CustomBossEvent bossBar;
+            if (barExists) {
+                bossBar = bossBarManager.get(barId);
+            } else {
+                bossBar = bossBarManager.create(barId, new TextComponent(barId.toString()));
+                if (DimensionType.OVERWORLD_EFFECTS.equals(worldId)) {
+                    bossBar.setColor(BossEvent.BossBarColor.GREEN);
+                } else if (DimensionType.NETHER_EFFECTS.equals(worldId)) {
+                    bossBar.setColor(BossEvent.BossBarColor.RED);
+                } else if (DimensionType.END_EFFECTS.equals(worldId)) {
+                    bossBar.setColor(BossEvent.BossBarColor.PURPLE);
+                } else {
+                    bossBar.setColor(BossEvent.BossBarColor.BLUE);
+                }
+            }
+            if (bossBar == null) {
+                continue;
+            }
+            final boolean silent = chunky.getOptions().isSilent();
+            if (silent && bossBar.isVisible() || !silent && !bossBar.isVisible()) {
+                bossBar.setVisible(!silent);
+            }
+            if (task == null) {
+                bossBar.removeAllPlayers();
+                bossBarManager.remove(bossBar);
+                continue;
+            }
+            for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+                if (player.hasPermissions(2)) {
+                    bossBar.addPlayer(player);
+                } else {
+                    bossBar.removePlayer(player);
+                }
+            }
+            final GenerationTask.Progress progress = task.getProgress();
+            bossBar.setName(new TextComponent(String.format("%s | %s%% | %s:%s:%s",
+                    worldId,
+                    String.format("%.2f", progress.getPercentComplete()),
+                    String.format("%01d", progress.getHours()),
+                    String.format("%02d", progress.getMinutes()),
+                    String.format("%02d", progress.getSeconds()))));
+            bossBar.setPercent(task.getProgress().getPercentComplete() / 100f);
+        }
+    }
+}

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
@@ -1,19 +1,20 @@
 package org.popcraft.chunky.platform;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.util.Unit;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.border.WorldBorder;
 import net.minecraft.world.level.chunk.ChunkStatus;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.storage.LevelResource;
 import org.popcraft.chunky.ChunkyForge;
 import org.popcraft.chunky.util.Coordinate;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -22,12 +23,12 @@ import java.util.concurrent.CompletableFuture;
 
 public class ForgeWorld implements World {
     private ServerLevel world;
-    private WorldBorder worldBorder;
+    private Border worldBorder;
     private static final TicketType<Unit> CHUNKY = TicketType.create(ChunkyForge.MODID, (unit, unit2) -> 0);
 
     public ForgeWorld(ServerLevel world) {
         this.world = world;
-        this.worldBorder = world.getWorldBorder();
+        this.worldBorder = new ForgeBorder(world.getWorldBorder());
     }
 
     @Override
@@ -37,7 +38,43 @@ public class ForgeWorld implements World {
 
     @Override
     public boolean isChunkGenerated(int x, int z) {
-        return false;
+        if (Thread.currentThread() != world.getServer().getRunningThread()) {
+            return CompletableFuture.supplyAsync(() -> isChunkGenerated(x, z), world.getServer()).join();
+        } else {
+            final ChunkPos chunkPos = new ChunkPos(x, z);
+            ChunkMap chunkStorage = world.getChunkSource().chunkMap;
+            ChunkHolder loadedChunkHolder = chunkStorage.getVisibleChunkIfPresent(chunkPos.toLong());
+            if (loadedChunkHolder != null && getLastAvailableStatus(loadedChunkHolder) == ChunkStatus.FULL) {
+                return true;
+            }
+            ChunkHolder unloadedChunkHolder = chunkStorage.pendingUnloads.get(chunkPos.toLong());
+            if (unloadedChunkHolder != null && getLastAvailableStatus(unloadedChunkHolder) == ChunkStatus.FULL) {
+                return true;
+            }
+            CompoundTag chunkNbt;
+            try {
+                chunkNbt = chunkStorage.readChunk(chunkPos);
+            } catch (IOException e) {
+                return false;
+            }
+            if (chunkNbt != null && chunkNbt.contains("Level", 10)) {
+                CompoundTag levelCompoundTag = chunkNbt.getCompound("Level");
+                if (levelCompoundTag.contains("Status", 8)) {
+                    return "full".equals(levelCompoundTag.getString("Status"));
+                }
+            }
+            return false;
+        }
+    }
+
+    private ChunkStatus getLastAvailableStatus(ChunkHolder chunkHolder) {
+        for(int i = ChunkHolder.CHUNK_STATUSES.size() - 1; i >= 0; --i) {
+            final ChunkStatus chunkStatus = ChunkHolder.CHUNK_STATUSES.get(i);
+            if (chunkHolder.getFutureIfPresentUnchecked(chunkStatus).getNow(ChunkHolder.UNLOADED_CHUNK).left().isPresent()) {
+                return chunkStatus;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -53,6 +90,7 @@ public class ForgeWorld implements World {
             ChunkHolder chunkHolder = chunkManager.getVisibleChunkIfPresent(chunkPos.toLong());
             if (chunkHolder == null) {
                 chunkFuture.complete(null);
+                world.getChunkSource().removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
             } else {
                 chunkManager.schedule(chunkHolder, ChunkStatus.FULL).thenAcceptAsync(either -> {
                     chunkFuture.complete(null);
@@ -81,7 +119,7 @@ public class ForgeWorld implements World {
 
     @Override
     public Border getWorldBorder() {
-        return new ForgeBorder(worldBorder);
+        return worldBorder;
     }
 
     @Override
@@ -105,5 +143,17 @@ public class ForgeWorld implements World {
         }
         Path directory = DimensionType.getStorageFolder(world.dimension(), world.getServer().getWorldPath(LevelResource.ROOT).toFile()).toPath().normalize().resolve(name);
         return Files.exists(directory) ? Optional.of(directory) : Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return world.equals(((ForgeWorld) o).world);
+    }
+
+    @Override
+    public int hashCode() {
+        return world.hashCode();
     }
 }

--- a/forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,5 +1,8 @@
-# ChunkManager
-public net.minecraft.world.server.ChunkManager field_219270_x # dimensionDirectory
-public net.minecraft.world.server.ChunkManager func_219219_b(J)Lnet/minecraft/world/server/ChunkHolder; # func_219219_b
-# ServerChunkProvider
-public net.minecraft.world.server.ServerChunkProvider func_217235_l()Z # func_217235_l
+# ChunkHolder
+public net.minecraft.world.server.ChunkHolder field_219310_e # CHUNK_STATUSES
+# ChunkMap
+public net.minecraft.world.server.ChunkManager func_219178_f(Lnet/minecraft/util/math/ChunkPos;)Lnet/minecraft/nbt/CompoundNBT; # readChunk
+public net.minecraft.world.server.ChunkManager func_219219_b(J)Lnet/minecraft/world/server/ChunkHolder; # getVisibleChunkIfPresent
+public net.minecraft.world.server.ChunkManager field_219253_g # pendingUnloads
+# ServerChunkCache
+public net.minecraft.world.server.ServerChunkProvider func_217235_l()Z # runDistanceManagerUpdates


### PR DESCRIPTION
This PR addresses the fact that multiple features / bug fixes have happened for Fabric that do not exist for Forge due to the period of time in which Forge was not being built.

I have done a complete diff between the two modules and have ported any fixes / features. I've also bumped the FML version to target the latest recommended build for 1.16.5.

Notable features include progress command, boss bars for client users, very fast chunk generated method, etc

Some interesting workarounds had to be done in some cases when porting, due to FML issues.

The getting of a chunk status had to be changed as FML lists the internal method as being client only - which is definitely not true, so a workaround had to be made via helper method.

The text component stuff in the boss bars was having an interesting remapping issue with FML, so I opted to use a more direct text component instead of the problematic method.