### PR TITLE
[Fabric] Simplify world and sender logic

### DIFF
--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricServer.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricServer.java
@@ -1,7 +1,6 @@
 package org.popcraft.chunky.platform;
 
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
@@ -37,11 +36,8 @@ public class FabricServer implements Server {
         if (worldIdentifier == null) {
             return Optional.empty();
         }
-        ServerWorld serverWorld = server.getWorld(RegistryKey.of(Registry.WORLD_KEY, worldIdentifier));
-        if (serverWorld == null) {
-            return Optional.empty();
-        }
-        return Optional.of(new FabricWorld(serverWorld));
+        return Optional.ofNullable(server.getWorld(RegistryKey.of(Registry.WORLD_KEY, worldIdentifier)))
+                .map(FabricWorld::new);
     }
 
     @Override


### PR DESCRIPTION
This PR simplifies some of the Fabric logic to align better with the Forge module.

This does come with a behavior change - instead of a `Console` sender being hardcoded to `x: 0, z: 0`, it will now actually return the position that the server provides (which is world spawn position, unless otherwise changed via `execute` command). 

This is the same behavior as Forge and is the most **correct** behavior compared to the other modules.