### PR TITLE
[Common] Fix SimpleScheduler behavior

### DIFF
--- a/common/src/main/java/org/popcraft/chunky/platform/impl/SimpleScheduler.java
+++ b/common/src/main/java/org/popcraft/chunky/platform/impl/SimpleScheduler.java
@@ -3,7 +3,7 @@ package org.popcraft.chunky.platform.impl;
 import org.popcraft.chunky.platform.Scheduler;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -12,12 +12,14 @@ public class SimpleScheduler implements Scheduler {
     private final ThreadGroup tasks = new ThreadGroup("tasks");
 
     public SimpleScheduler() {
-        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(3, Integer.MAX_VALUE, 5, TimeUnit.MINUTES, new LinkedBlockingQueue<>());
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(3, Integer.MAX_VALUE, 5, TimeUnit.MINUTES, new SynchronousQueue<>());
         threadPoolExecutor.setThreadFactory((runnable) -> {
             Thread thread = new Thread(tasks, runnable);
             thread.setDaemon(true);
             return thread;
         });
+        threadPoolExecutor.prestartAllCoreThreads();
+        threadPoolExecutor.allowCoreThreadTimeOut(true);
         this.executor = threadPoolExecutor;
     }
 


### PR DESCRIPTION
This PR addresses an undesirable behavior of SimpleScheduler.

The intended behavior of SimpleScheduler is to queue up tasks and execute them unbounded, with 3 threads ready to go upon startup that expire after 5 minutes if nothing happens. There should be an unlimited amount of tasks able to execute at the same time, given that the user wants to pregenerate a ton of worlds. We do not want to limit what users choose to do. We choose 3 as the initial thread count as there are three worlds in vanilla.

SimpleScheduler has three issues that differed from this intended functionality:
- The core threads were never being initialized on startup, so the whole "3 threads ready to go" wasn't actually happening until a task was first started.
- The core threads were never being allowed to expire, making the 5 minute TTL not apply to the first 3 threads
- The queue being used was a blocking FIFO, and it actually made the core thread count of 3 become a queue size which imposed an artificial hard limit of 3 worlds being generated at the same time. Any worlds past this would simply be queued until one of the currently running 3 were paused, finished or cancelled.

After discussions with you on making it behave as desired, this PR addresses the 3 bullet points above.