### PR TITLE
[Fabric/Forge] Use alternative chunk scheduling method

### DIFF
--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -79,7 +79,7 @@ public class FabricWorld implements World {
                 chunkFuture.complete(null);
                 serverWorld.getChunkManager().removeTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
             } else {
-                threadedAnvilChunkStorage.getChunk(chunkHolder, ChunkStatus.FULL).thenAcceptAsync(either -> {
+                chunkHolder.getChunkAt(ChunkStatus.FULL, threadedAnvilChunkStorage).thenAcceptAsync(either -> {
                     chunkFuture.complete(null);
                     serverWorld.getChunkManager().removeTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
                 }, serverWorld.getServer());

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
@@ -92,7 +92,7 @@ public class ForgeWorld implements World {
                 chunkFuture.complete(null);
                 world.getChunkSource().removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
             } else {
-                chunkManager.schedule(chunkHolder, ChunkStatus.FULL).thenAcceptAsync(either -> {
+                chunkHolder.getOrScheduleFuture(ChunkStatus.FULL, chunkManager).thenAcceptAsync(either -> {
                     chunkFuture.complete(null);
                     world.getChunkSource().removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
                 }, world.getServer());


### PR DESCRIPTION
This PR aims to make the chunk scheduling method use a potentially better alternative after looking through the server code.

(I will be using Mojang mapped class / method names for this analysis)

Currently, a chunk is scheduled to be brought to `FULL` status by using `ChunkMap#schedule(holder, status)`.

Upon looking through the server code, the only time `ChunkMap#schedule(holder, status)` is ever used internally is by `ChunkHolder#getOrScheduleFuture(status, chunkMap)`.

`ChunkHolder#getOrScheduleFuture(status, chunkMap)` is used much more commonly internally, and since it's still a caller of `ChunkMap#schedule(holder, status)` with a few extra checks, I believe it's better for us to use this purely for using the chunk system responsibly and in a way that coincides with the vanilla code.

I have seen zero changes regardless of method used, and have yet to see anyone have issues with the current method, so I have no idea if it even *really* matters, but it's something I've noticed internally regardless and feel we should use it *just incase*.

I encourage you to do your own testing and analysis to see if you come to the same conclusion.