### PR TITLE
[Sponge] Fix various configuration issues

### DIFF
--- a/sponge/src/main/java/org/popcraft/chunky/platform/SpongeConfig.java
+++ b/sponge/src/main/java/org/popcraft/chunky/platform/SpongeConfig.java
@@ -69,7 +69,7 @@ public class SpongeConfig implements Config {
         if (this.rootNode == null) {
             return Optional.empty();
         }
-        ConfigurationNode taskNode = rootNode.node("config", "tasks", world.getName());
+        ConfigurationNode taskNode = rootNode.node("tasks", world.getName());
         if (taskNode.virtual()) {
             return Optional.empty();
         }
@@ -103,7 +103,7 @@ public class SpongeConfig implements Config {
             this.rootNode = configLoader.createNode();
         }
         Selection selection = generationTask.getSelection();
-        ConfigurationNode taskNode = rootNode.node("config", "tasks", selection.world().getName());
+        ConfigurationNode taskNode = rootNode.node("tasks", selection.world().getName());
         String shape = generationTask.getShape().name();
         try {
             taskNode.node("cancelled").set(generationTask.isCancelled());
@@ -146,7 +146,7 @@ public class SpongeConfig implements Config {
 
     @Override
     public int getVersion() {
-        return this.rootNode == null ? 0 : this.rootNode.node("version").getInt(0);
+        return this.rootNode == null ? 0 : this.rootNode.node("config", "version").getInt(0);
     }
 
     @Override
@@ -154,12 +154,12 @@ public class SpongeConfig implements Config {
         if (this.rootNode == null) {
             return "en";
         }
-        return Input.checkLanguage(this.rootNode.node("language").getString("en"));
+        return Input.checkLanguage(this.rootNode.node("config", "language").getString("en"));
     }
 
     @Override
     public boolean getContinueOnRestart() {
-        return this.rootNode != null && this.rootNode.node("continue-on-restart").getBoolean(false);
+        return this.rootNode != null && this.rootNode.node("config", "continue-on-restart").getBoolean(false);
     }
 
     @Override

--- a/sponge/src/main/resources/main.conf
+++ b/sponge/src/main/resources/main.conf
@@ -1,7 +1,7 @@
 # Chunky Configuration
 # https://github.com/pop4959/Chunky/wiki/Configuration
 config {
-  version: 1
-  language: "en"
-  continue-on-restart: false
+  continue-on-restart=false
+  language=en
+  version=1
 }


### PR DESCRIPTION
This PR addresses a few configuration issues that exist with the Sponge module

- The `tasks` node was being placed inside of the `config` node instead of being its own root node
- `version`, `language` and `continue-on-restart` were told to be root nodes in the code, but were being shipped in the default configuration file as inside of the `config` node, leading to duplicate entries and only the ones at the root actually working
- The shipped default configuration file uses perfectly valid HOCON, but isn't the same style of HOCON that Configurate (and Sponge) use by default. It gets converted automatically on the users end.
- The shipped default configuration file isn't alphabetically sorted, so it will automatically get sorted when loaded on the server. Not really an issue, but it's best to keep the shipped config resembling the actual users config IMO.

All of the above have been resolved with this PR.