### PR TITLE
[Sponge] Implement "continue-on-restart" feature

### DIFF
--- a/sponge/src/main/java/org/popcraft/chunky/ChunkySponge.java
+++ b/sponge/src/main/java/org/popcraft/chunky/ChunkySponge.java
@@ -58,6 +58,9 @@ public class ChunkySponge {
         chunky.setLanguage(chunky.getConfig().getLanguage());
         chunky.loadCommands();
         Limit.set(chunky.getConfig());
+        if (chunky.getConfig().getContinueOnRestart()) {
+            chunky.getCommands().get("continue").execute(chunky.getServer().getConsoleSender(), new String[]{});
+        }
     }
 
     @Listener


### PR DESCRIPTION
This PR implements the `continue-on-restart` feature that all other platform modules have.

It properly waits until the server has loaded to execute, so should be compatible with any multi world mods/plugins similar to Bukkit.