### PR TITLE
[Forge] Update to 1.18

### DIFF
--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
-    id("dev.architectury.loom") version "0.7.4-SNAPSHOT"
+    id("dev.architectury.loom") version "0.10.0-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating
 
 dependencies {
-    minecraft(group = "com.mojang", name = "minecraft", version = "1.17.1")
-    mappings(minecraft.officialMojangMappings())
-    forge(group = "net.minecraftforge", name = "forge", version = "1.17.1-37.0.33")
+    minecraft(group = "com.mojang", name = "minecraft", version = "1.18")
+    mappings(loom.officialMojangMappings())
+    forge(group = "net.minecraftforge", name = "forge", version = "1.18-38.0.5")
     implementation(project(":chunky-common"))
     shade(project(":chunky-common"))
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(16))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 

--- a/forge/src/main/java/org/popcraft/chunky/ChunkyForge.java
+++ b/forge/src/main/java/org/popcraft/chunky/ChunkyForge.java
@@ -6,11 +6,11 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fmllegacy.server.ServerLifecycleHooks;
-import net.minecraftforge.fmlserverevents.FMLServerStartingEvent;
-import net.minecraftforge.fmlserverevents.FMLServerStoppingEvent;
+import net.minecraftforge.server.ServerLifecycleHooks;
 import org.popcraft.chunky.command.ChunkyCommand;
 import org.popcraft.chunky.command.CommandLiteral;
 import org.popcraft.chunky.command.suggestion.SuggestionProviders;
@@ -40,7 +40,7 @@ public class ChunkyForge {
     }
 
     @SubscribeEvent
-    public void onServerStarting(FMLServerStartingEvent event) {
+    public void onServerStarting(ServerStartingEvent event) {
         MinecraftServer server = event.getServer();
         File configFile = new File(event.getServer().getServerDirectory(), "config/chunky.json");
         this.chunky = new Chunky(new ForgeServer(this, server), new GsonConfig(() -> chunky, configFile));
@@ -161,7 +161,7 @@ public class ChunkyForge {
     }
 
     @SubscribeEvent
-    public void onServerStopping(FMLServerStoppingEvent event) {
+    public void onServerStopping(ServerStoppingEvent event) {
         chunky.disable();
     }
 

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
@@ -63,11 +63,8 @@ public class ForgeWorld implements World {
             } catch (IOException e) {
                 return false;
             }
-            if (chunkNbt != null && chunkNbt.contains("Level", 10)) {
-                CompoundTag levelCompoundTag = chunkNbt.getCompound("Level");
-                if (levelCompoundTag.contains("Status", 8)) {
-                    return "full".equals(levelCompoundTag.getString("Status"));
-                }
+            if (chunkNbt != null && chunkNbt.contains("Status", 8)) {
+                return "full".equals(chunkNbt.getString("Status"));
             }
             return false;
         }
@@ -160,7 +157,7 @@ public class ForgeWorld implements World {
         if (name == null) {
             return Optional.empty();
         }
-        Path directory = DimensionType.getStorageFolder(world.dimension(), world.getServer().getWorldPath(LevelResource.ROOT).toFile()).toPath().normalize().resolve(name);
+        Path directory = DimensionType.getStorageFolder(world.dimension(), world.getServer().getWorldPath(LevelResource.ROOT)).normalize().resolve(name);
         return Files.exists(directory) ? Optional.of(directory) : Optional.empty();
     }
 

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[37,)"
+loaderVersion="[38,)"
 license="GNU GPLv3"
 issueTrackerURL="${github}/issues"
 [[mods]]
@@ -13,12 +13,12 @@ description="${description}"
 [[dependencies.chunky]]
    modId="forge"
    mandatory=true
-   versionRange="[37,)"
+   versionRange="[38,)"
    ordering="NONE"
    side="BOTH"
 [[dependencies.chunky]]
    modId="minecraft"
    mandatory=true
-   versionRange="[1.17.1,1.18)"
+   versionRange="[1.18,1.19)"
    ordering="NONE"
    side="BOTH"

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "chunky resources",
-    "pack_format": 7
+    "pack_format": 8
   }
 }


### PR DESCRIPTION
This PR updates the Forge module to 1.18.

Not many changes were needed. I've ported all of the Fabric 1.18 fixes / changes.

Arch Loom was just updated a few hours ago for Forge 1.18 support, so it's still fresh and there appears to be a nasty looking stacktrace when building. It doesn't fail the build and the jar produced seems perfectly fine, so it's "safe" to ignore for now. It will likely resolve itself in future builds as we're building against an ever changing snapshot version.

I've tested all typical functionally of Chunky and all seems to work fine. (pregen, trim, world changing, boss bar in game, etc)