### PR TITLE
Add Squaremap Integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,11 @@ subprojects {
     group = "${project.property("group")}"
     version = "${project.property("version")}.${commitsSinceLastTag()}"
 
+    repositories {
+        mavenCentral()
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+
     java {
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(8))

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -1,4 +1,5 @@
 repositories {
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://papermc.io/repo/repository/maven-public")
 }
 

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ${name}
 version: ${version}
 main: ${group}.chunky.ChunkyBukkit
 api-version: 1.13
-softdepend: [dynmap, BlueMap, Pl3xMap, WorldBorder]
+softdepend: [dynmap, BlueMap, squaremap, WorldBorder]
 load: POSTWORLD
 authors: [${author}]
 description: ${description}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,15 +1,14 @@
 repositories {
-    mavenCentral()
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://repo.mikeprimm.com")
-    maven("https://repo.pl3x.net")
+    maven("https://repo.jpenilla.xyz/snapshots/")
     maven("https://jitpack.io")
 }
 
 dependencies {
     compileOnly(group = "us.dynmap", name = "dynmap-api", version = "3.1")
     compileOnly(group = "com.github.BlueMap-Minecraft", name = "BlueMapAPI", version = "v1.6.0")
-    compileOnly(group = "net.pl3x.map", name = "pl3xmap-api", version = "1.0.0-SNAPSHOT")
+    compileOnly(group = "xyz.jpenilla", name = "squaremap-api", version = "1.1.0-SNAPSHOT")
     compileOnly(group = "com.github.Brettflan", name = "WorldBorder", version = "c0d1772418")
     testImplementation(group = "junit", name = "junit", version = "4.13.2")
     testImplementation(group = "com.google.code.gson", name = "gson", version = "2.8.7")


### PR DESCRIPTION
This PR adds [Squaremap](https://github.com/jpenilla/squaremap) integration, which fully replaces the Pl3xMap integration. It also allows Chunky to compile again...

Pl3xMap has been archived and is no longer supported in any official capacity, and adding insult to injury, the pl3x maven repository is now giving a permanent `503` which prevents Chunky from continuing to support Pl3xMap, let alone compile... this effectively forces our hand in making a decision now rather than later, and it's clear Squaremap is the proper continuation of Pl3xMap.

This is a breaking change for anyone who still uses Pl3xMap - those users will either need to continue to use an old version of Chunky + ChunkyBorder or they will need to migrate to Squaremap. We should recommend the usage of Squaremap as a migration path going forward in support channels and documentation.

A corresponding PR will be made to ChunkyBorder after this PR has been merged, as this PR is a requisite due to the common changes and need to build against the appropriate version of Chunky.
