### PR TITLE
Allow Jitpack building.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+   - sdk install java 11.0.12-open
+   - sdk use java 11.0.12-open

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 before_install:
-   - sdk install java 11.0.12-open
-   - sdk use java 11.0.12-open
+   - sdk install java 17.0.1-open
+   - sdk use java 17.0.1-open


### PR DESCRIPTION
This should allow Jitpack to build this repository, this can be used by other plugin developers even though there is no official API.
I've set java 17 as the build version, feel free to change it, if this will get merged, example usages are listed below:

Bukkit example for Maven:
```xml
        <dependency>
            <groupId>com.github.pop4959.chunky</groupId>
            <artifactId>chunky-bukkit</artifactId> <!--This can be replaced with chunky-forge and other modules-->
            <version>version</version> <!--Release tag or commit can be used (See jitpack for my fork for further [info](https://jitpack.io/#kyngs/chunky). You can see that the latest commit is successfully built )-->
        </dependency>
```

