### PR TITLE
Fix Fabric devlaunch

### DIFF
--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ServerChunkManagerMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ServerChunkManagerMixin.java
@@ -8,5 +8,5 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 public interface ServerChunkManagerMixin {
     @Invoker("tick")
     @SuppressWarnings({"UnusedReturnValue", "UnnecessaryInterfaceModifier"})
-    public boolean tick();
+    public boolean invokeTick();
 }

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageMixin.java
@@ -16,10 +16,10 @@ import java.util.concurrent.CompletableFuture;
 @Mixin(ThreadedAnvilChunkStorage.class)
 public interface ThreadedAnvilChunkStorageMixin {
     @Invoker("getChunkHolder")
-    public ChunkHolder getChunkHolder(long pos);
+    public ChunkHolder invokeGetChunkHolder(long pos);
 
     @Invoker("getUpdatedChunkNbt")
-    public CompletableFuture<Optional<NbtCompound>> getUpdatedChunkNbt(ChunkPos pos);
+    public CompletableFuture<Optional<NbtCompound>> invokeGetUpdatedChunkNbt(ChunkPos pos);
 
     @Accessor("chunksToUnload")
     public Long2ObjectLinkedOpenHashMap<ChunkHolder> getChunksToUnload();

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -54,7 +54,7 @@ public class FabricWorld implements World {
             final ChunkPos chunkPos = new ChunkPos(x, z);
             ThreadedAnvilChunkStorage chunkStorage = serverWorld.getChunkManager().threadedAnvilChunkStorage;
             ThreadedAnvilChunkStorageMixin chunkStorageMixin = (ThreadedAnvilChunkStorageMixin) chunkStorage;
-            ChunkHolder loadedChunkHolder = chunkStorageMixin.getChunkHolder(chunkPos.toLong());
+            ChunkHolder loadedChunkHolder = chunkStorageMixin.invokeGetChunkHolder(chunkPos.toLong());
             if (loadedChunkHolder != null && loadedChunkHolder.getCurrentStatus() == ChunkStatus.FULL) {
                 return true;
             }
@@ -62,7 +62,7 @@ public class FabricWorld implements World {
             if (unloadedChunkHolder != null && unloadedChunkHolder.getCurrentStatus() == ChunkStatus.FULL) {
                 return true;
             }
-            return chunkStorageMixin.getUpdatedChunkNbt(chunkPos).join().map(chunkNbt -> chunkNbt.contains("Status", 8) && "full".equals(chunkNbt.getString("Status"))).orElse(false);
+            return chunkStorageMixin.invokeGetUpdatedChunkNbt(chunkPos).join().map(chunkNbt -> chunkNbt.contains("Status", 8) && "full".equals(chunkNbt.getString("Status"))).orElse(false);
         }
     }
 
@@ -74,10 +74,10 @@ public class FabricWorld implements World {
             final ChunkPos chunkPos = new ChunkPos(x, z);
             final ServerChunkManager serverChunkManager = serverWorld.getChunkManager();
             serverChunkManager.addTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
-            ((ServerChunkManagerMixin) serverChunkManager).tick();
+            ((ServerChunkManagerMixin) serverChunkManager).invokeTick();
             final ThreadedAnvilChunkStorage threadedAnvilChunkStorage = serverChunkManager.threadedAnvilChunkStorage;
             final ThreadedAnvilChunkStorageMixin threadedAnvilChunkStorageMixin = (ThreadedAnvilChunkStorageMixin) threadedAnvilChunkStorage;
-            final ChunkHolder chunkHolder = threadedAnvilChunkStorageMixin.getChunkHolder(chunkPos.toLong());
+            final ChunkHolder chunkHolder = threadedAnvilChunkStorageMixin.invokeGetChunkHolder(chunkPos.toLong());
             final CompletableFuture<Void> chunkFuture = chunkHolder == null ? CompletableFuture.completedFuture(null) : CompletableFuture.allOf(chunkHolder.getChunkAt(ChunkStatus.FULL, threadedAnvilChunkStorage));
             chunkFuture.whenCompleteAsync((ignored, throwable) -> serverChunkManager.removeTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), serverWorld.getServer());
             return chunkFuture;


### PR DESCRIPTION
When using Chunky in mapped Fabric devlaunch, the implementation of mixin accessor interfaces into Vanilla classes causes recursive invocation due to matching method names, which then causes a stack overflow. This pull request prepends `invoke` to the invoker methods to prevent name conflicts in mapped environments, per standard.

Stack trace: 
```
java.lang.StackOverflowError: Exception initializing level
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	at net.minecraft.server.world.ThreadedAnvilChunkStorage.getChunkHolder(ThreadedAnvilChunkStorage.java)
	..... many more frames
        at net.minecraft.server.MinecraftServer.createWorlds(MinecraftServer.java:368)
	at net.minecraft.server.MinecraftServer.loadWorld(MinecraftServer.java:316)
	at net.minecraft.server.dedicated.MinecraftDedicatedServer.setupServer(MinecraftDedicatedServer.java:172)
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:637)
	at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:258)
	at java.base/java.lang.Thread.run(Thread.java:833)

```