### PR TITLE
Tweak Bukkit teleporting vehicles logic

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitPlayer.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitPlayer.java
@@ -4,8 +4,15 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+import org.popcraft.chunky.Chunky;
+import org.popcraft.chunky.ChunkyBukkit;
 import org.popcraft.chunky.platform.util.Location;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -62,14 +69,32 @@ public class BukkitPlayer extends BukkitSender implements Player {
     public void teleport(final Location location) {
         final org.bukkit.World world = Bukkit.getWorld(location.getWorld().getName());
         final org.bukkit.Location loc = new org.bukkit.Location(world, location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
-        final Entity vehicle = player.getVehicle();
-        teleportAsync(player, loc);
+        final Vehicle vehicle = (Vehicle) player.getVehicle();
         if (vehicle != null) {
-            teleportAsync(vehicle, loc).thenAccept(success -> {
-                if (Boolean.TRUE.equals(success)) {
-                    vehicle.addPassenger(player);
+            final List<Entity> passengers = new ArrayList<>(vehicle.getPassengers());
+            vehicle.eject();
+            runTask(() -> teleportAsync(vehicle, loc).thenAccept(vehicleTpResult -> {
+                if (Boolean.TRUE.equals(vehicleTpResult)) {
+                    runTask(() -> passengers.forEach(passenger -> {
+                                teleportAsync(passenger, loc).thenAccept(passengerTpResult -> {
+                                    if (Boolean.TRUE.equals(passengerTpResult)) {
+                                        if (passenger instanceof org.bukkit.entity.Player) {
+                                            refreshEntity((org.bukkit.entity.Player) passenger, vehicle);
+                                        }
+                                        runTask(() -> vehicle.addPassenger(passenger), 1);
+                                    }
+                                });
+                                runTask(() -> {
+                                    if (passenger instanceof org.bukkit.entity.Player) {
+                                        refreshEntity((org.bukkit.entity.Player) passenger, vehicle);
+                                    }
+                                }, 1);
+                            }
+                    ), 1);
                 }
-            });
+            }), 1);
+        } else {
+            teleportAsync(player, loc);
         }
     }
 
@@ -79,6 +104,15 @@ public class BukkitPlayer extends BukkitSender implements Player {
         } else {
             return CompletableFuture.completedFuture(entity.teleport(location));
         }
+    }
+
+    private static void runTask(final Runnable runnable, final long ticks) {
+        Bukkit.getScheduler().runTaskLater(JavaPlugin.getPlugin(ChunkyBukkit.class), runnable, ticks);
+    }
+
+    public static void refreshEntity(final org.bukkit.entity.Player player, final org.bukkit.entity.Entity entity) {
+        player.hideEntity(JavaPlugin.getPlugin(ChunkyBukkit.class), entity);
+        player.showEntity(JavaPlugin.getPlugin(ChunkyBukkit.class), entity);
     }
 
     @Override


### PR DESCRIPTION
Based on this plugin that does it: https://github.com/TheMrJezza/HorseTpWithMe/blob/master/src/main/java/com/jbouchier/horsetpwithme/util/BlinkTeleportUtil.java

It mostly works, minecarts and pigs on a saddle and horses. Boats for some reason get teleported, however only a client reload shows the boat present.

I have never coded for a Bukkit plugin before so any and all changes/constructive criticism are welcome. Thank you :)