### PR TITLE
Fix vanilla block entity tickers memory leak

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -14,6 +14,10 @@ dependencies {
     shade(project(":chunky-common"))
 }
 
+loom {
+    accessWidenerPath = file("src/main/resources/chunky.accesswidener")
+}
+
 tasks {
     processResources {
         filesMatching("fabric.mod.json") {

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ServerChunkManagerAccessor.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ServerChunkManagerAccessor.java
@@ -5,7 +5,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(ServerChunkManager.class)
-public interface ServerChunkManagerMixin {
+public interface ServerChunkManagerAccessor {
     @Invoker("updateChunks")
     @SuppressWarnings({"UnusedReturnValue", "UnnecessaryInterfaceModifier"})
     public boolean invokeUpdateChunks();

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageAccessor.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageAccessor.java
@@ -1,0 +1,26 @@
+package org.popcraft.chunky.mixin;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ChunkHolder;
+import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+import net.minecraft.util.math.ChunkPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@SuppressWarnings("UnnecessaryInterfaceModifier")
+@Mixin(ThreadedAnvilChunkStorage.class)
+public interface ThreadedAnvilChunkStorageAccessor {
+    @Invoker("getChunkHolder")
+    public ChunkHolder invokeGetChunkHolder(long pos);
+
+    @Invoker("getUpdatedChunkNbt")
+    public CompletableFuture<Optional<NbtCompound>> invokeGetUpdatedChunkNbt(ChunkPos pos);
+
+    @Accessor("chunksToUnload")
+    public Long2ObjectLinkedOpenHashMap<ChunkHolder> getChunksToUnload();
+}

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageMixin.java
@@ -1,34 +1,18 @@
 package org.popcraft.chunky.mixin;
 
-import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.WorldChunk;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Accessor;
-import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-@SuppressWarnings("UnnecessaryInterfaceModifier")
 @Mixin(ThreadedAnvilChunkStorage.class)
-public abstract class ThreadedAnvilChunkStorageMixin {
-    @Invoker("getChunkHolder")
-    public abstract ChunkHolder invokeGetChunkHolder(long pos);
-
-    @Invoker("getUpdatedChunkNbt")
-    public abstract CompletableFuture<Optional<NbtCompound>> invokeGetUpdatedChunkNbt(ChunkPos pos);
-
-    @Accessor("chunksToUnload")
-    public abstract Long2ObjectLinkedOpenHashMap<ChunkHolder> getChunksToUnload();
-
+public class ThreadedAnvilChunkStorageMixin {
     // Block entity tickers memory leak fixed by removing the unloaded chunk's block entity tickers from the world,
     // avoiding the memory leak as well as increasing tick performance relatively to block entities.
     // If we don't remove the block entity tickers, they will get accumulated in the world while chunks get generated.

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ThreadedAnvilChunkStorageMixin.java
@@ -5,22 +5,36 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.WorldChunk;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("UnnecessaryInterfaceModifier")
 @Mixin(ThreadedAnvilChunkStorage.class)
-public interface ThreadedAnvilChunkStorageMixin {
+public abstract class ThreadedAnvilChunkStorageMixin {
     @Invoker("getChunkHolder")
-    public ChunkHolder invokeGetChunkHolder(long pos);
+    public abstract ChunkHolder invokeGetChunkHolder(long pos);
 
     @Invoker("getUpdatedChunkNbt")
-    public CompletableFuture<Optional<NbtCompound>> invokeGetUpdatedChunkNbt(ChunkPos pos);
+    public abstract CompletableFuture<Optional<NbtCompound>> invokeGetUpdatedChunkNbt(ChunkPos pos);
 
     @Accessor("chunksToUnload")
-    public Long2ObjectLinkedOpenHashMap<ChunkHolder> getChunksToUnload();
+    public abstract Long2ObjectLinkedOpenHashMap<ChunkHolder> getChunksToUnload();
+
+    // Block entity tickers memory leak fixed by removing the unloaded chunk's block entity tickers from the world,
+    // avoiding the memory leak as well as increasing tick performance relatively to block entities.
+    // If we don't remove the block entity tickers, they will get accumulated in the world while chunks get generated.
+    @Inject(method = "method_18843(Lnet/minecraft/server/world/ChunkHolder;Ljava/util/concurrent/CompletableFuture;JLnet/minecraft/world/chunk/Chunk;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;unloadEntities(Lnet/minecraft/world/chunk/WorldChunk;)V"))
+    private void unloadBlockEntityTickers(ChunkHolder chunkHolder, CompletableFuture<Chunk> completableFuture, long l, Chunk chunk, CallbackInfo ci) {
+        ((WorldChunk) chunk).getWorld().blockEntityTickers.removeAll(((WorldChunk) chunk).blockEntityTickers.values());
+    }
 }

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -65,17 +65,17 @@ public class FabricWorld implements World {
             final ChunkPos chunkPos = new ChunkPos(x, z);
             final ServerChunkManager serverChunkManager = serverWorld.getChunkManager();
             final ThreadedAnvilChunkStorage chunkStorage = serverChunkManager.threadedAnvilChunkStorage;
-            final ThreadedAnvilChunkStorageAccessor chunkStorageMixin = (ThreadedAnvilChunkStorageAccessor) chunkStorage;
-            final ChunkHolder loadedChunkHolder = chunkStorageMixin.invokeGetChunkHolder(chunkPos.toLong());
+            final ThreadedAnvilChunkStorageAccessor chunkStorageAccessor = (ThreadedAnvilChunkStorageAccessor) chunkStorage;
+            final ChunkHolder loadedChunkHolder = chunkStorageAccessor.invokeGetChunkHolder(chunkPos.toLong());
             if (loadedChunkHolder != null && loadedChunkHolder.getCurrentStatus() == ChunkStatus.FULL) {
                 return CompletableFuture.completedFuture(true);
             }
-            final ChunkHolder unloadedChunkHolder = chunkStorageMixin.getChunksToUnload().get(chunkPos.toLong());
+            final ChunkHolder unloadedChunkHolder = chunkStorageAccessor.getChunksToUnload().get(chunkPos.toLong());
             if (unloadedChunkHolder != null && unloadedChunkHolder.getCurrentStatus() == ChunkStatus.FULL) {
                 return CompletableFuture.completedFuture(true);
             }
             if (UPDATE_CHUNK_NBT) {
-                return chunkStorageMixin.invokeGetUpdatedChunkNbt(chunkPos)
+                return chunkStorageAccessor.invokeGetUpdatedChunkNbt(chunkPos)
                         .thenApply(optionalNbt -> optionalNbt
                                 .filter(chunkNbt -> chunkNbt.contains("Status", NbtElement.STRING_TYPE))
                                 .map(chunkNbt -> chunkNbt.getString("Status"))
@@ -108,8 +108,8 @@ public class FabricWorld implements World {
             }
             ((ServerChunkManagerAccessor) serverChunkManager).invokeUpdateChunks();
             final ThreadedAnvilChunkStorage threadedAnvilChunkStorage = serverChunkManager.threadedAnvilChunkStorage;
-            final ThreadedAnvilChunkStorageAccessor threadedAnvilChunkStorageMixin = (ThreadedAnvilChunkStorageAccessor) threadedAnvilChunkStorage;
-            final ChunkHolder chunkHolder = threadedAnvilChunkStorageMixin.invokeGetChunkHolder(chunkPos.toLong());
+            final ThreadedAnvilChunkStorageAccessor threadedAnvilChunkStorageAccessor = (ThreadedAnvilChunkStorageAccessor) threadedAnvilChunkStorage;
+            final ChunkHolder chunkHolder = threadedAnvilChunkStorageAccessor.invokeGetChunkHolder(chunkPos.toLong());
             final CompletableFuture<Void> chunkFuture = chunkHolder == null ? CompletableFuture.completedFuture(null) : CompletableFuture.allOf(chunkHolder.getChunkAt(ChunkStatus.FULL, threadedAnvilChunkStorage));
             chunkFuture.whenCompleteAsync((ignored, throwable) -> serverChunkManager.removeTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), serverWorld.getServer());
             return chunkFuture;

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -22,8 +22,8 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.Heightmap;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.dimension.DimensionType;
-import org.popcraft.chunky.mixin.ServerChunkManagerMixin;
-import org.popcraft.chunky.mixin.ThreadedAnvilChunkStorageMixin;
+import org.popcraft.chunky.mixin.ServerChunkManagerAccessor;
+import org.popcraft.chunky.mixin.ThreadedAnvilChunkStorageAccessor;
 import org.popcraft.chunky.platform.util.Location;
 import org.popcraft.chunky.util.Input;
 
@@ -65,7 +65,7 @@ public class FabricWorld implements World {
             final ChunkPos chunkPos = new ChunkPos(x, z);
             final ServerChunkManager serverChunkManager = serverWorld.getChunkManager();
             final ThreadedAnvilChunkStorage chunkStorage = serverChunkManager.threadedAnvilChunkStorage;
-            final ThreadedAnvilChunkStorageMixin chunkStorageMixin = (ThreadedAnvilChunkStorageMixin) chunkStorage;
+            final ThreadedAnvilChunkStorageAccessor chunkStorageMixin = (ThreadedAnvilChunkStorageAccessor) chunkStorage;
             final ChunkHolder loadedChunkHolder = chunkStorageMixin.invokeGetChunkHolder(chunkPos.toLong());
             if (loadedChunkHolder != null && loadedChunkHolder.getCurrentStatus() == ChunkStatus.FULL) {
                 return CompletableFuture.completedFuture(true);
@@ -106,9 +106,9 @@ public class FabricWorld implements World {
             if (TICKING_LOAD_DURATION > 0) {
                 serverChunkManager.addTicket(CHUNKY_TICKING, chunkPos, 1, Unit.INSTANCE);
             }
-            ((ServerChunkManagerMixin) serverChunkManager).invokeUpdateChunks();
+            ((ServerChunkManagerAccessor) serverChunkManager).invokeUpdateChunks();
             final ThreadedAnvilChunkStorage threadedAnvilChunkStorage = serverChunkManager.threadedAnvilChunkStorage;
-            final ThreadedAnvilChunkStorageMixin threadedAnvilChunkStorageMixin = (ThreadedAnvilChunkStorageMixin) threadedAnvilChunkStorage;
+            final ThreadedAnvilChunkStorageAccessor threadedAnvilChunkStorageMixin = (ThreadedAnvilChunkStorageAccessor) threadedAnvilChunkStorage;
             final ChunkHolder chunkHolder = threadedAnvilChunkStorageMixin.invokeGetChunkHolder(chunkPos.toLong());
             final CompletableFuture<Void> chunkFuture = chunkHolder == null ? CompletableFuture.completedFuture(null) : CompletableFuture.allOf(chunkHolder.getChunkAt(ChunkStatus.FULL, threadedAnvilChunkStorage));
             chunkFuture.whenCompleteAsync((ignored, throwable) -> serverChunkManager.removeTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), serverWorld.getServer());

--- a/fabric/src/main/resources/chunky.accesswidener
+++ b/fabric/src/main/resources/chunky.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v2 named
+accessible field net/minecraft/world/chunk/WorldChunk blockEntityTickers Ljava/util/Map;
+accessible field net/minecraft/world/World blockEntityTickers Ljava/util/List;

--- a/fabric/src/main/resources/chunky.mixins.json
+++ b/fabric/src/main/resources/chunky.mixins.json
@@ -4,7 +4,8 @@
   "package": "org.popcraft.chunky.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "ServerChunkManagerMixin",
+    "ServerChunkManagerAccessor",
+    "ThreadedAnvilChunkStorageAccessor",
     "ThreadedAnvilChunkStorageMixin"
   ],
   "client": [

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,6 +25,7 @@
   "mixins": [
     "chunky.mixins.json"
   ],
+  "accessWidener": "chunky.accesswidener",
   "depends": {
     "fabricloader": ">=0.15.10",
     "fabric": "*",


### PR DESCRIPTION
Block entity tickers in World are not being removed correctly when unloading a WorldChunk, which leads to a memory leak as well as decreasing tick performance relatively to block entities. If we don't remove the block entity tickers, they will get accumulated in the world while chunks get generated. 

You can verify that statement if you create a heapdump of a server (using Spark for example) after a long time generating chunks (in my tests, ~10000 chunks radius), under the retained objects.

I only created a pull request for the Fabric side of the project since I don't really know how to mod using any other mod loader (and I don't know if that will be even possible with plugin loaders).