### PR TITLE
Fix vehicle teleports on folia

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitPlayer.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitPlayer.java
@@ -72,7 +72,7 @@ public class BukkitPlayer extends BukkitSender implements Player {
         } else if (Paper.isPaper() && player.getWorld().equals(loc.getWorld())) {
             Paper.teleportAsyncWithPassengers(vehicle, loc);
         } else if (Folia.isFolia() && !Folia.isTickThread(player.getLocation())) {
-            Folia.schedule(plugin, player, () -> teleport(location));
+            Folia.schedule(plugin, player, () -> teleport(location), 1);
         } else {
             final List<Entity> passengers = vehicle.getPassengers();
             vehicle.eject();
@@ -88,7 +88,7 @@ public class BukkitPlayer extends BukkitSender implements Player {
                 }
             }, command -> {
                 if (Folia.isFolia()) {
-                    Folia.schedule(plugin, player, command);
+                    Folia.schedule(plugin, player, command, 1);
                 } else {
                     plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, command, 1);
                 }

--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitPlayer.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitPlayer.java
@@ -69,14 +69,11 @@ public class BukkitPlayer extends BukkitSender implements Player {
         final Entity vehicle = player.getVehicle();
         if (vehicle == null) {
             teleportAsync(player, loc);
-        } else if (Paper.isPaper() && loc.getWorld() == player.getWorld()) {
+        } else if (Paper.isPaper() && player.getWorld().equals(loc.getWorld())) {
             Paper.teleportAsyncWithPassengers(vehicle, loc);
+        } else if (Folia.isFolia() && !Folia.isTickThread(player.getLocation())) {
+            Folia.schedule(plugin, player, () -> teleport(location));
         } else {
-            if (Folia.isFolia() && !Folia.isTickThread(player.getLocation())) {
-                Folia.schedule(plugin, player, () -> teleport(location));
-                return;
-            }
-
             final List<Entity> passengers = vehicle.getPassengers();
             vehicle.eject();
             teleportAsync(player, loc).thenAcceptAsync(ignored -> {
@@ -90,10 +87,11 @@ public class BukkitPlayer extends BukkitSender implements Player {
                     vehicle.addPassenger(passenger);
                 }
             }, command -> {
-                if (Folia.isFolia())
+                if (Folia.isFolia()) {
                     Folia.schedule(plugin, player, command);
-                else
+                } else {
                     plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, command, 1);
+                }
             });
         }
     }

--- a/folia/src/main/java/org/popcraft/chunky/platform/Folia.java
+++ b/folia/src/main/java/org/popcraft/chunky/platform/Folia.java
@@ -3,9 +3,11 @@ package org.popcraft.chunky.platform;
 import io.papermc.paper.threadedregions.RegionizedServerInitEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 public final class Folia {
     private static final boolean CONFIG_EXISTS = classExists("io.papermc.paper.threadedregions.RegionizedServer") || classExists("io.papermc.paper.threadedregions.RegionizedServerInitEvent");
@@ -21,6 +23,10 @@ public final class Folia {
         Bukkit.getServer().getRegionScheduler().execute(plugin, location, runnable);
     }
 
+    public static void schedule(final Plugin plugin, final Entity entity, final Runnable runnable) {
+        entity.getScheduler().execute(plugin, runnable, () -> {}, 1L);
+    }
+
     public static void scheduleFixed(final Plugin plugin, final Location location, final Runnable runnable, final long delay, final long period) {
         Bukkit.getServer().getRegionScheduler().runAtFixedRate(plugin, location, ignored -> runnable.run(), delay, period);
     }
@@ -31,6 +37,10 @@ public final class Folia {
 
     public static void cancelTasks(final Plugin plugin) {
         Bukkit.getServer().getGlobalRegionScheduler().cancelTasks(plugin);
+    }
+
+    public static boolean isTickThread(final @NotNull Location location) {
+        return Bukkit.getServer().isOwnedByCurrentRegion(location);
     }
 
     public static void onServerInit(final Plugin plugin, final Runnable runnable) {

--- a/folia/src/main/java/org/popcraft/chunky/platform/Folia.java
+++ b/folia/src/main/java/org/popcraft/chunky/platform/Folia.java
@@ -23,8 +23,8 @@ public final class Folia {
         Bukkit.getServer().getRegionScheduler().execute(plugin, location, runnable);
     }
 
-    public static void schedule(final Plugin plugin, final Entity entity, final Runnable runnable) {
-        entity.getScheduler().execute(plugin, runnable, () -> {}, 1L);
+    public static void schedule(final Plugin plugin, final Entity entity, final Runnable runnable, final long delay) {
+        entity.getScheduler().execute(plugin, runnable, () -> {}, delay);
     }
 
     public static void scheduleFixed(final Plugin plugin, final Location location, final Runnable runnable, final long delay, final long period) {

--- a/paper/src/main/java/org/popcraft/chunky/platform/Paper.java
+++ b/paper/src/main/java/org/popcraft/chunky/platform/Paper.java
@@ -1,9 +1,11 @@
 package org.popcraft.chunky.platform;
 
+import io.papermc.paper.entity.TeleportFlag;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -23,6 +25,10 @@ public final class Paper {
 
     public static CompletableFuture<Boolean> teleportAsync(final Entity entity, final Location location) {
         return entity.teleportAsync(location);
+    }
+
+    public static CompletableFuture<Boolean> teleportAsyncWithPassengers(final Entity entity, final Location location) {
+        return entity.teleportAsync(location, PlayerTeleportEvent.TeleportCause.PLUGIN, TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
     }
 
     private static boolean classExists(final String clazz) {


### PR DESCRIPTION
Fixes teleporting players with vehicles on folia since I encountered some issues with this in chunkyborder. The teleport flag api is used for same world teleports and the rest of the method is modified to make sure we're on the region thread for the player.