### PR TITLE
Support detecting generated ancient chunks

### DIFF
--- a/nbt/src/main/java/org/popcraft/chunky/nbt/ByteArrayTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/ByteArrayTag.java
@@ -37,12 +37,6 @@ public class ByteArrayTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.BYTE_ARRAY;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/ByteTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/ByteTag.java
@@ -32,12 +32,6 @@ public class ByteTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.BYTE;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/CompoundTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/CompoundTag.java
@@ -3,6 +3,7 @@ package org.popcraft.chunky.nbt;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -75,6 +76,10 @@ public class CompoundTag extends Tag {
         }
         compoundBuilder.append(indent).append('}');
         return compoundBuilder.toString();
+    }
+
+    public Collection<Tag> values() {
+        return value.values();
     }
 
     public Optional<Tag> get(final String name) {

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/DoubleTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/DoubleTag.java
@@ -32,12 +32,6 @@ public class DoubleTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.DOUBLE;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/EndTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/EndTag.java
@@ -25,12 +25,6 @@ public class EndTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.END;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/FloatTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/FloatTag.java
@@ -32,12 +32,6 @@ public class FloatTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.FLOAT;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/IntArrayTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/IntArrayTag.java
@@ -42,12 +42,6 @@ public class IntArrayTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.INT_ARRAY;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/IntTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/IntTag.java
@@ -32,12 +32,6 @@ public class IntTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.INT;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/ListTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/ListTag.java
@@ -53,12 +53,6 @@ public class ListTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.LIST;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/LongArrayTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/LongArrayTag.java
@@ -42,12 +42,6 @@ public class LongArrayTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.LONG_ARRAY;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/LongTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/LongTag.java
@@ -32,12 +32,6 @@ public class LongTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.LONG;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/ShortTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/ShortTag.java
@@ -32,12 +32,6 @@ public class ShortTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.SHORT;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/StringTag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/StringTag.java
@@ -33,12 +33,6 @@ public class StringTag extends Tag {
     }
 
     @Override
-    public Tag search(final DataInput input, final byte type, final String name) throws IOException {
-        skip(input);
-        return null;
-    }
-
-    @Override
     public byte type() {
         return TagType.STRING;
     }

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/Tag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/Tag.java
@@ -87,7 +87,10 @@ public abstract class Tag {
 
     abstract void write(final DataOutput output) throws IOException;
 
-    abstract Tag search(final DataInput input, final byte type, final String name) throws IOException;
+    Tag search(final DataInput input, final byte type, final String name) throws IOException  {
+        skip(input);
+        return null;
+    }
 
     abstract byte type();
 

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/Tag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/Tag.java
@@ -60,22 +60,24 @@ public abstract class Tag {
     }
 
     public static CompoundTag multiFind(final DataInput input, final Map<String, Byte> tags) throws IOException {
-        final CompoundTag result = new CompoundTag("root");
-        byte t;
+        final CompoundTag result = new CompoundTag("");
+        byte type;
+        String name;
+        Tag tag;
 
-        while(true) {
-            t = input.readByte();
-            if (TagType.END == t) {
+        while (true) {
+            type = input.readByte();
+            if (TagType.END == type) {
                 return result;
             }
 
-            final String n = input.readUTF();
-            final Tag tag = create(t, n);
-            if (tags.containsKey(n) && tags.get(n).equals(t)) {
+            name = input.readUTF();
+            tag = create(type, name);
+            if (tags.containsKey(name) && tags.get(name).equals(type)) {
                 tag.read(input);
 
                 result.put(tag);
-            } else if (t == TagType.COMPOUND) {
+            } else if (type == TagType.COMPOUND) {
                 Tag.multiFind(input, tags).values().forEach(result::put);
             } else {
                 tag.skip(input);

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/Tag.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/Tag.java
@@ -64,11 +64,17 @@ public abstract class Tag {
         byte type;
         String name;
         Tag tag;
+        int end_tag_count = -1;
 
         while (true) {
             type = input.readByte();
             if (TagType.END == type) {
-                return result;
+                if (end_tag_count <= 0) {
+                    return result;
+                } else {
+                    --end_tag_count;
+                    continue;
+                }
             }
 
             name = input.readUTF();
@@ -78,7 +84,7 @@ public abstract class Tag {
 
                 result.put(tag);
             } else if (type == TagType.COMPOUND) {
-                Tag.multiFind(input, tags).values().forEach(result::put);
+                ++end_tag_count;
             } else {
                 tag.skip(input);
             }
@@ -114,7 +120,7 @@ public abstract class Tag {
 
     abstract void write(final DataOutput output) throws IOException;
 
-    Tag search(final DataInput input, final byte type, final String name) throws IOException  {
+    Tag search(final DataInput input, final byte type, final String name) throws IOException {
         skip(input);
         return null;
     }


### PR DESCRIPTION
Alright, so it took me a bit of messing around to figure this one out.

In all honesty, I'm not sure how sensical this change is, but it does fix my issue. I'll be doing a tad more testing later to see if the data I'm seeing is the result of some weird stuff I did to the worlds or if it's actually vanilla data.  
I decided to forgo the lighting check, for the reason that the only way the world pattern makes sense is just for loading all chunks anyways and I figured loading these chunks is safe, as just lighting is missing.

I won't be mad if you don't merge this either. This is primarily for fixing the issue I came across myself and I'm unsure of how applicable this is for general audiences.