### PR TITLE
Fix folia region getting stuck when World#getElevation is used

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
@@ -127,8 +127,8 @@ public class BukkitWorld implements World {
 
     @Override
     public int getElevation(final int x, final int z) {
-        if (Folia.isFolia()) {
-            final org.bukkit.Location location = new org.bukkit.Location(world, x, 0, z);
+        final org.bukkit.Location location = new org.bukkit.Location(world, x, 0, z);
+        if (Folia.isFolia() && !Folia.isTickThread(location)) {
             return CompletableFuture
                     .supplyAsync(() -> getElevationForLocation(x, z), command -> Folia.schedule(plugin, location, command))
                     .join();


### PR DESCRIPTION
When World#getElevation is called from a region thread for a location that's owned by that same region, it causes the region to get "stuck" since the completablefuture can never finish.

![image](https://github.com/user-attachments/assets/5e64d756-5912-44ad-835c-588ca4b0630c)
(For reproduction, I used getElevation with the player's x and z coords inside onCommand)