### PR TITLE
Port fabric to 1.21.3 and prevent pausing during pregen tasks

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,14 +1,14 @@
 plugins {
-    id("dev.architectury.loom") version "1.6-SNAPSHOT"
+    id("dev.architectury.loom") version "1.7-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating
 
 dependencies {
-    minecraft(group = "com.mojang", name = "minecraft", version = "1.21")
+    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.3")
     mappings(loom.officialMojangMappings())
-    modImplementation(group = "net.fabricmc", name = "fabric-loader", version = "0.15.11")
-    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.100.1+1.21")
+    modImplementation(group = "net.fabricmc", name = "fabric-loader", version = "0.16.7")
+    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.107.0+1.21.3")
     modCompileOnly(group = "me.lucko", name = "fabric-permissions-api", version = "0.2-SNAPSHOT")
     implementation(project(":chunky-common"))
     shade(project(":chunky-common"))

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 val shade: Configuration by configurations.creating
 
 dependencies {
-    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.3")
+    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.2")
     mappings(loom.officialMojangMappings())
     modImplementation(group = "net.fabricmc", name = "fabric-loader", version = "0.16.7")
-    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.107.0+1.21.3")
+    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.106.1+1.21.2")
     modCompileOnly(group = "me.lucko", name = "fabric-permissions-api", version = "0.2-SNAPSHOT")
     implementation(project(":chunky-common"))
     shade(project(":chunky-common"))

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
@@ -10,8 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
-
-    @Shadow private int emptyTicks;
+    @Shadow
+    private int emptyTicks;
 
     @Inject(method = "tickServer", at = @At("HEAD"))
     private void preventPausing(CallbackInfo ci) {
@@ -19,5 +19,4 @@ public class MinecraftServerMixin {
             this.emptyTicks = 0;
         }
     }
-
 }

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
@@ -1,0 +1,23 @@
+package org.popcraft.chunky.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.popcraft.chunky.ChunkyProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+
+    @Shadow private int emptyTicks;
+
+    @Inject(method = "tickServer", at = @At("HEAD"))
+    private void preventPausing(CallbackInfo ci) {
+        if (!ChunkyProvider.get().getGenerationTasks().isEmpty()) {
+            this.emptyTicks = 0;
+        }
+    }
+
+}

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricPlayer.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricPlayer.java
@@ -2,8 +2,10 @@ package org.popcraft.chunky.platform;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Relative;
 import org.popcraft.chunky.platform.util.Location;
 
+import java.util.EnumSet;
 import java.util.UUID;
 
 import static org.popcraft.chunky.util.Translator.translateKey;
@@ -48,7 +50,7 @@ public class FabricPlayer extends FabricSender implements Player {
 
     @Override
     public void teleport(final Location location) {
-        player.teleportTo(((FabricWorld) location.getWorld()).getWorld(), location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
+        player.teleportTo(((FabricWorld) location.getWorld()).getWorld(), location.getX(), location.getY(), location.getZ(), EnumSet.noneOf(Relative.class), location.getYaw(), location.getPitch(), true /* from TeleportCommand */);
     }
 
     @Override

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricPlayer.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricPlayer.java
@@ -50,7 +50,7 @@ public class FabricPlayer extends FabricSender implements Player {
 
     @Override
     public void teleport(final Location location) {
-        player.teleportTo(((FabricWorld) location.getWorld()).getWorld(), location.getX(), location.getY(), location.getZ(), EnumSet.noneOf(Relative.class), location.getYaw(), location.getPitch(), true /* from TeleportCommand */);
+        player.teleportTo(((FabricWorld) location.getWorld()).getWorld(), location.getX(), location.getY(), location.getZ(), EnumSet.noneOf(Relative.class), location.getYaw(), location.getPitch(), true);
     }
 
     @Override

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -137,7 +137,7 @@ public class FabricWorld implements World {
         if (height >= logicalHeight) {
             BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(x, logicalHeight, z);
             int air = 0;
-            while (pos.getY() > world.getMinBuildHeight()) {
+            while (pos.getY() > world.getMinY()) {
                 pos = pos.move(Direction.DOWN);
                 final BlockState blockState = world.getBlockState(pos);
                 if (blockState.isSolid() && air > 1) {
@@ -166,8 +166,8 @@ public class FabricWorld implements World {
         final Location location = player.getLocation();
         world.getServer()
                 .registryAccess()
-                .registry(Registries.SOUND_EVENT)
-                .flatMap(soundEventRegistry -> soundEventRegistry.getOptional(ResourceLocation.tryParse(sound)))
+                .get(Registries.SOUND_EVENT)
+                .flatMap(soundEventRegistry -> soundEventRegistry.value().getOptional(ResourceLocation.tryParse(sound)))
                 .ifPresent(soundEvent -> world.playSound(null, location.getX(), location.getY(), location.getZ(), soundEvent, SoundSource.MASTER, 2f, 1f));
     }
 

--- a/fabric/src/main/resources/chunky.mixins.json
+++ b/fabric/src/main/resources/chunky.mixins.json
@@ -4,8 +4,9 @@
   "package": "org.popcraft.chunky.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "ServerChunkCacheMixin",
-    "ChunkMapMixin"
+    "ChunkMapMixin",
+    "MinecraftServerMixin",
+    "ServerChunkCacheMixin"
   ],
   "client": [
   ],

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -26,9 +26,9 @@
     "chunky.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.11",
+    "fabricloader": ">=0.16.7",
     "fabric": "*",
-    "minecraft": ">=1.21-rc.1",
+    "minecraft": ">=1.21.2",
     "java": ">=21"
   },
   "custom": {

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("dev.architectury.loom") version "1.6-SNAPSHOT"
+    id("dev.architectury.loom") version "1.7-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("dev.architectury.loom") version "1.6-SNAPSHOT"
+    id("dev.architectury.loom") version "1.7-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating


### PR DESCRIPTION
Dedicated server now pauses automatically since 24w33a. Pausing causes trouble for the vanilla chunk system, and therefore this PR unpauses the server while it is doing generation tasks. 