### PR TITLE
fix: memory pressure when the game is paused during pregen

### DIFF
--- a/fabric/src/main/java/org/popcraft/chunky/ducks/MinecraftServerExtension.java
+++ b/fabric/src/main/java/org/popcraft/chunky/ducks/MinecraftServerExtension.java
@@ -1,0 +1,11 @@
+package org.popcraft.chunky.ducks;
+
+import java.util.function.BooleanSupplier;
+
+public interface MinecraftServerExtension {
+
+    void chunky$runChunkSystemHousekeeping(BooleanSupplier haveTime);
+
+    void chunky$markChunkSystemHousekeeping();
+
+}

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ChunkMapMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ChunkMapMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BooleanSupplier;
 
 @SuppressWarnings("UnnecessaryInterfaceModifier")
 @Mixin(ChunkMap.class)
@@ -18,4 +19,7 @@ public interface ChunkMapMixin {
 
     @Invoker("readChunk")
     public CompletableFuture<Optional<CompoundTag>> invokeReadChunk(ChunkPos pos);
+
+    @Invoker
+    void invokeTick(BooleanSupplier booleanSupplier);
 }

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/ServerChunkCacheMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/ServerChunkCacheMixin.java
@@ -17,4 +17,7 @@ public interface ServerChunkCacheMixin {
                                                                                       final int chunkZ,
                                                                                       final ChunkStatus toStatus,
                                                                                       final boolean create);
+
+    @Invoker
+    boolean invokeRunDistanceManagerUpdates();
 }

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/client/IntegratedServerMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/client/IntegratedServerMixin.java
@@ -1,0 +1,20 @@
+package org.popcraft.chunky.mixin.client;
+
+import net.minecraft.client.server.IntegratedServer;
+import org.popcraft.chunky.ducks.MinecraftServerExtension;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.BooleanSupplier;
+
+@Mixin(IntegratedServer.class)
+public abstract class IntegratedServerMixin implements MinecraftServerExtension {
+
+    @Inject(method = "tickServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/server/IntegratedServer;tickPaused()V"))
+    private void tickPaused(BooleanSupplier booleanSupplier, CallbackInfo ci) {
+        this.chunky$runChunkSystemHousekeeping(booleanSupplier);
+    }
+
+}

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.chunk.status.ChunkStatus;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.storage.LevelResource;
+import org.popcraft.chunky.ducks.MinecraftServerExtension;
 import org.popcraft.chunky.mixin.ChunkMapMixin;
 import org.popcraft.chunky.mixin.ServerChunkCacheMixin;
 import org.popcraft.chunky.platform.util.Location;
@@ -104,7 +105,10 @@ public class FabricWorld implements World {
             }
             ((ServerChunkCacheMixin) serverChunkCache).invokeRunDistanceManagerUpdates();
             return ((ServerChunkCacheMixin) world.getChunkSource()).invokeGetChunkFutureMainThread(x, z, ChunkStatus.FULL, false)
-                    .whenCompleteAsync((ignored, throwable) -> serverChunkCache.removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), world.getServer())
+                    .whenCompleteAsync((ignored, throwable) -> {
+                        serverChunkCache.removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE);
+                        ((MinecraftServerExtension) world.getServer()).chunky$markChunkSystemHousekeeping();
+                    }, world.getServer())
                     .thenApply(ignored -> null);
         }
     }

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -102,9 +102,10 @@ public class FabricWorld implements World {
             if (TICKING_LOAD_DURATION > 0) {
                 serverChunkCache.addRegionTicket(CHUNKY_TICKING, chunkPos, 1, Unit.INSTANCE);
             }
-            final CompletableFuture<Void> chunkFuture = CompletableFuture.allOf(((ServerChunkCacheMixin) world.getChunkSource()).invokeGetChunkFutureMainThread(x, z, ChunkStatus.FULL, true));
-            chunkFuture.whenCompleteAsync((ignored, throwable) -> serverChunkCache.removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), world.getServer());
-            return chunkFuture;
+            ((ServerChunkCacheMixin) serverChunkCache).invokeRunDistanceManagerUpdates();
+            return ((ServerChunkCacheMixin) world.getChunkSource()).invokeGetChunkFutureMainThread(x, z, ChunkStatus.FULL, false)
+                    .whenCompleteAsync((ignored, throwable) -> serverChunkCache.removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), world.getServer())
+                    .thenApply(ignored -> null);
         }
     }
 

--- a/fabric/src/main/resources/chunky.mixins.json
+++ b/fabric/src/main/resources/chunky.mixins.json
@@ -9,6 +9,7 @@
     "ServerChunkCacheMixin"
   ],
   "client": [
+    "client.IntegratedServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/neoforge/src/main/java/org/popcraft/chunky/platform/NeoForgeWorld.java
+++ b/neoforge/src/main/java/org/popcraft/chunky/platform/NeoForgeWorld.java
@@ -100,10 +100,10 @@ public class NeoForgeWorld implements World {
             if (TICKING_LOAD_DURATION > 0) {
                 serverChunkCache.addRegionTicket(CHUNKY_TICKING, chunkPos, 1, Unit.INSTANCE);
             }
-            final CompletableFuture<Void> chunkFuture = CompletableFuture.allOf(world.getChunkSource().getChunkFutureMainThread(x, z, ChunkStatus.FULL, true));
-            chunkFuture.whenCompleteAsync((ignored, throwable) -> serverChunkCache.removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), world.getServer());
-            chunkFuture.thenAcceptAsync((ignored) -> world.getServer().emptyTicks = 0);
-            return chunkFuture;
+            serverChunkCache.runDistanceManagerUpdates();
+            return serverChunkCache.getChunkFutureMainThread(x, z, ChunkStatus.FULL, false)
+                    .whenCompleteAsync((ignored, throwable) -> serverChunkCache.removeRegionTicket(CHUNKY, chunkPos, 0, Unit.INSTANCE), world.getServer())
+                    .thenApply(ignored -> null);
         }
     }
 

--- a/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -5,3 +5,4 @@ public net.minecraft.server.level.ChunkMap readChunk(Lnet/minecraft/world/level/
 public net.minecraft.server.level.ChunkMap getVisibleChunkIfPresent(J)Lnet/minecraft/server/level/ChunkHolder;
 # ServerChunkCache
 public net.minecraft.server.level.ServerChunkCache getChunkFutureMainThread(IILnet/minecraft/world/level/chunk/status/ChunkStatus;Z)Ljava/util/concurrent/CompletableFuture;
+public net.minecraft.server.level.ServerChunkCache runDistanceManagerUpdates()Z


### PR DESCRIPTION
Fixes #333

- avoids adding UNKNOWN tickets when generating
- runs chunk system housekeeping tasks during pregen only when paused
