### PR TITLE
Properly resolve rare Folia region blockages when retrieving getElevation, using managedBlock, using managedBlock

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
@@ -144,7 +144,11 @@ public class BukkitWorld implements World {
     }
 
     private static void runManagedBlock(org.bukkit.World world, CompletableFuture<Integer> toComplete) throws Exception {
-        Object serverLevel = world.getClass().getMethod("getHandle").invoke(world);
+        Object runningLevel = world.getClass().getMethod("getHandle").invoke(world);
+        Object currentWorldData = runningLevel.getClass().getMethod("getCurrentWorldData").invoke(world);
+
+        java.lang.reflect.Field worldField = currentWorldData.getClass().getField("world");
+        Object serverLevel = worldField.get(currentWorldData);
 
         java.lang.reflect.Field chunkSourceField = serverLevel.getClass().getField("chunkSource");
         Object chunkSource = chunkSourceField.get(serverLevel);

--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
@@ -146,7 +146,7 @@ public class BukkitWorld implements World {
     public static void runManagedBlock(org.bukkit.World world, CompletableFuture<Integer> toComplete) throws Exception {
         Object serverLevel = world.getClass().getMethod("getHandle").invoke(world);
 
-        java.lang.reflect.Field chunkSourceField = serverLevel.getClass().getField("chunkSource"); // public field
+        java.lang.reflect.Field chunkSourceField = serverLevel.getClass().getField("chunkSource");
         Object chunkSource = chunkSourceField.get(serverLevel);
 
         java.lang.reflect.Field mainThreadProcessorField = chunkSource.getClass().getDeclaredField("mainThreadProcessor");

--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
@@ -129,12 +129,32 @@ public class BukkitWorld implements World {
     public int getElevation(final int x, final int z) {
         final org.bukkit.Location location = new org.bukkit.Location(world, x, 0, z);
         if (Folia.isFolia() && !Folia.isTickThread(location)) {
-            return CompletableFuture
-                    .supplyAsync(() -> getElevationForLocation(x, z), command -> Folia.schedule(plugin, location, command))
-                    .join();
+            CompletableFuture<Integer> future =
+                CompletableFuture.supplyAsync(() -> getElevationForLocation(x, z), command
+                    -> Folia.schedule(plugin, location, command));
+            try {
+                runManagedBlock(world, future);
+                return future.get();
+            } catch (Exception e) {
+                throw new RuntimeException("Couldn't run managed block for fetching elevation", e);
+            }
         } else {
             return getElevationForLocation(x, z);
         }
+    }
+
+    public static void runManagedBlock(org.bukkit.World world, CompletableFuture<Integer> toComplete) throws Exception {
+        Object serverLevel = world.getClass().getMethod("getHandle").invoke(world);
+
+        java.lang.reflect.Field chunkSourceField = serverLevel.getClass().getField("chunkSource"); // public field
+        Object chunkSource = chunkSourceField.get(serverLevel);
+
+        java.lang.reflect.Field mainThreadProcessorField = chunkSource.getClass().getDeclaredField("mainThreadProcessor");
+        mainThreadProcessorField.setAccessible(true);
+        Object mainThreadProcessor = mainThreadProcessorField.get(chunkSource);
+
+        java.lang.reflect.Method managedBlockMethod = mainThreadProcessor.getClass().getMethod("managedBlock", java.util.function.BooleanSupplier.class);
+        managedBlockMethod.invoke(mainThreadProcessor, (java.util.function.BooleanSupplier) toComplete::isDone);
     }
 
     private int getElevationForLocation(final int x, final int z) {

--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
@@ -143,7 +143,7 @@ public class BukkitWorld implements World {
         }
     }
 
-    public static void runManagedBlock(org.bukkit.World world, CompletableFuture<Integer> toComplete) throws Exception {
+    private static void runManagedBlock(org.bukkit.World world, CompletableFuture<Integer> toComplete) throws Exception {
         Object serverLevel = world.getClass().getMethod("getHandle").invoke(world);
 
         java.lang.reflect.Field chunkSourceField = serverLevel.getClass().getField("chunkSource");


### PR DESCRIPTION
This properly resolves rare conditions with getElevation which cause regions to effectively implode. Although this is a rare race condition, it is very much real and should be dealt with promptly. The previously applied fix did not adequately resolve this, since blocking with `.join` on Folia is simply not a good strategy.