### PR TITLE
Force chunk load on elevation check

### DIFF
--- a/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
+++ b/bukkit/src/main/java/org/popcraft/chunky/platform/BukkitWorld.java
@@ -148,6 +148,7 @@ public class BukkitWorld implements World {
     private int getElevationForLocation(final int x, final int z) {
         final int height = world.getHighestBlockYAt(x, z) + 1;
         final int logicalHeight = world.getLogicalHeight();
+        final CompletableFuture loadedChunk = getChunkAtAsync(x >> 4, y >> 4);
         if (height >= logicalHeight) {
             Block block = world.getBlockAt(x, logicalHeight, z);
             int air = 0;

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -137,6 +137,7 @@ public class FabricWorld implements World {
     public int getElevation(final int x, final int z) {
         final int height = world.getHeight(Heightmap.Types.MOTION_BLOCKING, x, z) + 1;
         final int logicalHeight = world.getLogicalHeight();
+        final CompletableFuture loadedChunk = getChunkAtAsync(x >> 4, y >> 4);
         if (height >= logicalHeight) {
             BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(x, logicalHeight, z);
             int air = 0;

--- a/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
+++ b/forge/src/main/java/org/popcraft/chunky/platform/ForgeWorld.java
@@ -140,6 +140,7 @@ public class ForgeWorld implements World {
     public int getElevation(final int x, final int z) {
         final int height = world.getHeight(Heightmap.Types.MOTION_BLOCKING, x, z) + 1;
         final int logicalHeight = world.getLogicalHeight();
+        final CompletableFuture loadedChunk = getChunkAtAsync(x >> 4, y >> 4);
         if (height >= logicalHeight) {
             BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(x, logicalHeight, z);
             int air = 0;

--- a/neoforge/src/main/java/org/popcraft/chunky/platform/NeoForgeWorld.java
+++ b/neoforge/src/main/java/org/popcraft/chunky/platform/NeoForgeWorld.java
@@ -134,6 +134,7 @@ public class NeoForgeWorld implements World {
     public int getElevation(final int x, final int z) {
         final int height = world.getHeight(Heightmap.Types.MOTION_BLOCKING, x, z) + 1;
         final int logicalHeight = world.getLogicalHeight();
+        final CompletableFuture loadedChunk = getChunkAtAsync(x >> 4, y >> 4);
         if (height >= logicalHeight) {
             BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(x, logicalHeight, z);
             int air = 0;


### PR DESCRIPTION
When `BlockState` is called on a block that is within a chunk that has yet to be loaded, it will always return `nil`. This results in a situation wherein the height found by the elevation check will always return -63Y in these cases.

This commmit attempts to fix this by forcing an asynchronous chunk load of the destination chunk before elevation is calculated.

This is most apparent in ChunkyBorder, wherein a worldwrap teleport would attempt to position the player in a chunk that had yet to be loaded, or even exist, always teleporting them to -63Y

See: https://github.com/pop4959/ChunkyBorder/issues/91