### PR TITLE
Moonrise compat again

### DIFF
--- a/fabric/src/main/java/org/popcraft/chunky/ChunkyFabric.java
+++ b/fabric/src/main/java/org/popcraft/chunky/ChunkyFabric.java
@@ -40,6 +40,7 @@ import static net.minecraft.commands.arguments.DimensionArgument.dimension;
 import static net.minecraft.commands.arguments.EntityArgument.player;
 
 public class ChunkyFabric implements ModInitializer {
+    public static final boolean ENABLE_MOONRISE_WORKAROUNDS = FabricLoader.getInstance().isModLoaded("moonrise");
     private Chunky chunky;
     private final Map<ResourceLocation, ServerBossEvent> bossBars = new ConcurrentHashMap<>();
 

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerAccess.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerAccess.java
@@ -1,0 +1,11 @@
+package org.popcraft.chunky.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MinecraftServer.class)
+public interface MinecraftServerAccess {
+    @Accessor
+    void setEmptyTicks(int value);
+}

--- a/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
+++ b/fabric/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
@@ -2,6 +2,7 @@ package org.popcraft.chunky.mixin;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import org.popcraft.chunky.ChunkyFabric;
 import org.popcraft.chunky.ChunkyProvider;
 import org.popcraft.chunky.ducks.MinecraftServerExtension;
 import org.spongepowered.asm.mixin.Mixin;
@@ -32,7 +33,10 @@ public abstract class MinecraftServerMixin implements MinecraftServerExtension {
         if (this.chunky$needChunkSystemHousekeeping.compareAndSet(true, false)) {
             for (ServerLevel level : this.getAllLevels()) {
                 ((ChunkMapMixin) level.getChunkSource().chunkMap).invokeTick(haveTime);
-                ((ServerLevelMixin) level).getEntityManager().tick();
+                if (!ChunkyFabric.ENABLE_MOONRISE_WORKAROUNDS) {
+                    // note: Moonrise destroys the vanilla entity system, so skip it here if it's present
+                    ((ServerLevelMixin) level).getEntityManager().tick();
+                }
             }
         }
     }

--- a/fabric/src/main/resources/chunky.mixins.json
+++ b/fabric/src/main/resources/chunky.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ChunkMapMixin",
+    "MinecraftServerAccess",
     "MinecraftServerMixin",
     "ServerChunkCacheMixin",
     "ServerLevelMixin"

--- a/neoforge/src/main/java/org/popcraft/chunky/ChunkyNeoForge.java
+++ b/neoforge/src/main/java/org/popcraft/chunky/ChunkyNeoForge.java
@@ -9,6 +9,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.common.NeoForge;
@@ -45,6 +46,7 @@ import static net.minecraft.commands.arguments.EntityArgument.player;
 @Mod(ChunkyNeoForge.MOD_ID)
 public class ChunkyNeoForge {
     public static final String MOD_ID = "chunky";
+    public static final boolean ENABLE_MOONRISE_WORKAROUNDS = ModList.get().isLoaded("moonrise");
     private Chunky chunky;
     private final Map<ResourceLocation, ServerBossEvent> bossBars = new ConcurrentHashMap<>();
 

--- a/neoforge/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
+++ b/neoforge/src/main/java/org/popcraft/chunky/mixin/MinecraftServerMixin.java
@@ -2,6 +2,7 @@ package org.popcraft.chunky.mixin;
 
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import org.popcraft.chunky.ChunkyNeoForge;
 import org.popcraft.chunky.ducks.MinecraftServerExtension;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -31,7 +32,10 @@ public abstract class MinecraftServerMixin implements MinecraftServerExtension {
         if (this.chunky$needChunkSystemHousekeeping.compareAndSet(true, false)) {
             for (ServerLevel level : this.getAllLevels()) {
                 level.getChunkSource().chunkMap.tick(haveTime);
-                level.entityManager.tick();
+                if (!ChunkyNeoForge.ENABLE_MOONRISE_WORKAROUNDS) {
+                    // note: Moonrise destroys the vanilla entity system, so skip it here if it's present
+                    level.entityManager.tick();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR introduces specific workarounds for unusual behaviors when Moonrise is present on Fabric and NeoForge. 

Fixes #360 again, and another crash, but reintroduces #333 for Moonrise users.  
Alternative methods for solving the pausing issues for everyone with a single code path has not been found at the time of writing. 
