### PR TITLE
Update to Minecraft 1.21.9

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,14 +1,14 @@
 plugins {
-    id("dev.architectury.loom") version "1.10-SNAPSHOT"
+    id("dev.architectury.loom") version "1.11-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating
 
 dependencies {
-    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.6")
+    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.9")
     mappings(loom.officialMojangMappings())
-    modImplementation(group = "net.fabricmc", name = "fabric-loader", version = "0.16.14")
-    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.127.1+1.21.6")
+    modImplementation(group = "net.fabricmc", name = "fabric-loader", version = "0.17.2")
+    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.133.14+1.21.9")
     modCompileOnly(group = "me.lucko", name = "fabric-permissions-api", version = "0.4.0")
     implementation(project(":chunky-common"))
     shade(project(":chunky-common"))

--- a/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
+++ b/fabric/src/main/java/org/popcraft/chunky/platform/FabricWorld.java
@@ -37,8 +37,9 @@ import java.util.function.Function;
 
 public class FabricWorld implements World {
     private static final int TICKING_LOAD_DURATION = Input.tryInteger(System.getProperty("chunky.tickingLoadDuration")).orElse(0);
-    private static final TicketType CHUNKY = new TicketType(0L, false, TicketType.TicketUse.LOADING);
-    private static final TicketType CHUNKY_TICKING = new TicketType(TICKING_LOAD_DURATION * 20L, false, TicketType.TicketUse.LOADING_AND_SIMULATION);
+    // In 1.21.9, TicketType constructor is (long timeout, int flags)
+    private static final TicketType CHUNKY = new TicketType(0L, TicketType.FLAG_LOADING);
+    private static final TicketType CHUNKY_TICKING = new TicketType(TICKING_LOAD_DURATION * 20L, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION);
     private static final boolean UPDATE_CHUNK_NBT = Boolean.getBoolean("chunky.updateChunkNbt");
     private final ServerLevel world;
     private final Border worldBorder;
@@ -132,8 +133,10 @@ public class FabricWorld implements World {
 
     @Override
     public Location getSpawn() {
-        final BlockPos pos = world.getSharedSpawnPos();
-        final float rot = world.getSharedSpawnAngle();
+        // In 1.21.9, spawn is now in RespawnData
+        var respawnData = world.getRespawnData();
+        final BlockPos pos = respawnData.pos();
+        final float rot = respawnData.yaw();
         return new Location(this, pos.getX(), pos.getY(), pos.getZ(), rot, 0);
     }
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -26,9 +26,9 @@
     "chunky.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.16.14",
+    "fabricloader": ">=0.17.2",
     "fabric": "*",
-    "minecraft": ">=1.21.6",
+    "minecraft": ">=1.21.9",
     "java": ">=21"
   },
   "custom": {

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("dev.architectury.loom") version "1.10-SNAPSHOT"
+    id("dev.architectury.loom") version "1.11-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("dev.architectury.loom") version "1.10-SNAPSHOT"
+    id("dev.architectury.loom") version "1.11-SNAPSHOT"
 }
 
 val shade: Configuration by configurations.creating


### PR DESCRIPTION
- Update Fabric Loader to 0.17.2
- Update Fabric API to 0.133.14+1.21.9
- Update Loom to 1.11-SNAPSHOT across all modules
- Fix TicketType constructor for 1.21.9 (now uses flags instead of TicketUse enum)
- Fix spawn position API (now uses RespawnData)
- Bump version to 1.4.50