### PR TITLE
skip over .backup files

### DIFF
--- a/common/src/main/java/org/popcraft/chunky/util/ChunkCoordinate.java
+++ b/common/src/main/java/org/popcraft/chunky/util/ChunkCoordinate.java
@@ -8,6 +8,9 @@ public record ChunkCoordinate(int x, int z) implements Comparable<ChunkCoordinat
         if (!regionFileName.startsWith("r.")) {
             return Optional.empty();
         }
+        if (!regionFileName.endsWith(".mca")) {
+            return Optional.empty();
+        }
         final int extension = regionFileName.indexOf(".mca");
         if (extension < 2) {
             return Optional.empty();

--- a/nbt/src/main/java/org/popcraft/chunky/nbt/util/RegionFile.java
+++ b/nbt/src/main/java/org/popcraft/chunky/nbt/util/RegionFile.java
@@ -35,6 +35,9 @@ public final class RegionFile {
             if (!regionFileName.startsWith("r.")) {
                 return;
             }
+            if (!regionFileName.endsWith(".mca")) {
+                return;
+            }
             final int extension = regionFileName.indexOf(".mca");
             if (extension < 2) {
                 return;


### PR DESCRIPTION
Backup files such as "r.0.1.mca.-4425446270485561675.backup" are not skipped and throw an UnsupportedOperationException, halting the trim process with no error message.